### PR TITLE
Add MultiCNOT gate.

### DIFF
--- a/qoqo/src/operations/mod.rs
+++ b/qoqo/src/operations/mod.rs
@@ -179,5 +179,6 @@ pub fn operations(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PhaseShiftState0Wrapper>()?;
     m.add_class::<PhaseShiftState1Wrapper>()?;
     m.add_class::<MultiQubitMSWrapper>()?;
+    m.add_class::<MultiCNOTWrapper>()?;
     Ok(())
 }

--- a/qoqo/src/operations/multi_qubit_gate_operations.rs
+++ b/qoqo/src/operations/multi_qubit_gate_operations.rs
@@ -34,3 +34,11 @@ pub struct MultiQubitMS {
     /// The angle of the multi qubit Molmer-Sorensen gate.
     theta: CalculatorFloat,
 }
+
+#[allow(clippy::upper_case_acronyms)]
+#[wrap(Operate, OperateMultiQubit, OperateGate, OperateMultiQubitGate)]
+/// The CNOT gate with multiple controls
+pub struct MultiCNOT {
+    /// The qubits involved in the MultiCNOT gate.
+    qubits: Vec<usize>,
+}


### PR DESCRIPTION
This adds a NOT gate with multiple controls. I also added the corresponding things to the [qasm backend](SolidTux/qoqo_qasm@e504bd4).

A conversion to a circuit is only implemented for 2 (which is of course redundant as CNOT exists) and 3. Maybe a dedicated CCNOT gate would be better, but I was not sure how to make that fit into the trait structure.

In general it would be great to make writing custom gates outside of this crate (at least for Rust code) and have `Circuit` return `Vec<Box<dyn Operate>>` or something similar instead of `Vec<Operation>`. But I don't know how that works on the Python side (and also how interoperation between two Python libraries with Rust backends works).