### PR TITLE
BasisRotation measurement renamed to PauliZProduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This changelog track changes to the qoqo project starting at version 0.5.0
 * Semver-style version checking for Circuit serialization. In beta mode (0.y.z) minor version must match (y_library == y_data) in release mode (x.y.z) major version must match (x_library == x_data) and minor version of library must exceed minor version of data (y_library >= y_data).
 * `json_schema` implementing `JsonSchema` from schemars for roqoqo data structures
 
+### Changed
+* BasisRotation and CheatedBasisRotation measurements renamed to PauliZProduct and CheatedPauliZProduct measurement to reflect that this is the measurement of the PauliProduct in the z-basis.
+
+
 ## 0.10.0
 
 ### Fixed 0.10.0

--- a/qoqo/qoqo/do_unitary/do_unitary.py
+++ b/qoqo/qoqo/do_unitary/do_unitary.py
@@ -33,7 +33,7 @@ class DoUnitary(object):
     2) The unitary evolution phase is a circuit with gates usually representing a certain
        Hamiltonian, repeated a certain number of times or Trotter steps.
     3) The measurement phase is the measurement of certain expectation values. These are
-       defined in terms of pauli product expectations, such as the BasisRotation
+       defined in terms of pauli product expectations, such as the PauliZProduct
        (in qoqo -> measurements).
     """
 

--- a/qoqo/src/measurements/basis_rotation_measurement.rs
+++ b/qoqo/src/measurements/basis_rotation_measurement.rs
@@ -12,42 +12,42 @@
 
 //! Qoqo basis rotation measurement.
 
-use super::BasisRotationInputWrapper;
+use super::PauliZProductInputWrapper;
 use crate::CircuitWrapper;
 use bincode::serialize;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyByteArray;
 use pyo3::types::PyType;
-use roqoqo::measurements::BasisRotation;
+use roqoqo::measurements::PauliZProduct;
 use roqoqo::prelude::*;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::Circuit;
 use std::collections::HashMap;
-#[pyclass(name = "BasisRotation", module = "qoqo.measurements")]
+#[pyclass(name = "PauliZProduct", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a basis rotation measurement.
-pub struct BasisRotationWrapper {
-    /// Internal storage of [roqoqo::BasisRotation].
-    pub internal: BasisRotation,
+pub struct PauliZProductWrapper {
+    /// Internal storage of [roqoqo::PauliZProduct].
+    pub internal: PauliZProduct,
 }
 
 #[pymethods]
-impl BasisRotationWrapper {
-    /// Create a new BasisRotation measurement.
+impl PauliZProductWrapper {
+    /// Create a new PauliZProduct measurement.
     ///
     /// Args:
     ///     constant_circuit (Optional[Circuit]): The constant Circuit that is executed before each Circuit in circuits.
     ///     circuits (list[Circuit]): The collection of quantum circuits for the separate basis rotations.
-    ///     input (BasisRotationInput): The additional input information required for measurement.
+    ///     input (PauliZProductInput): The additional input information required for measurement.
     ///
     /// Returns:
-    ///     BasisRotation: The BasisRotation containing the new basis rotation measurement.
+    ///     PauliZProduct: The PauliZProduct containing the new basis rotation measurement.
     #[new]
     pub fn new(
         constant_circuit: Option<CircuitWrapper>,
         circuits: Vec<CircuitWrapper>,
-        input: BasisRotationInputWrapper,
+        input: PauliZProductInputWrapper,
     ) -> Self {
         let new_circuits: Vec<Circuit> = circuits.into_iter().map(|c| c.internal).collect();
         let new_constant: Option<Circuit> = match constant_circuit {
@@ -55,7 +55,7 @@ impl BasisRotationWrapper {
             Some(c) => Some(c.internal),
         };
         Self {
-            internal: BasisRotation {
+            internal: PauliZProduct {
                 constant_circuit: new_constant,
                 circuits: new_circuits,
                 input: input.internal,
@@ -148,10 +148,10 @@ impl BasisRotationWrapper {
     /// Returns the measurement input data defining how to construct expectation values from measurements.
     ///
     /// Returns:
-    ///     BasisRotationInput: The measurment input of BasisRotation.
-    pub fn input(&self) -> BasisRotationInputWrapper {
+    ///     PauliZProductInput: The measurment input of PauliZProduct.
+    pub fn input(&self) -> PauliZProductInputWrapper {
         let input = self.internal.input.clone();
-        BasisRotationInputWrapper { internal: input }
+        PauliZProductInputWrapper { internal: input }
     }
 
     /// Returns the type of the measurement in string form.
@@ -159,7 +159,7 @@ impl BasisRotationWrapper {
     /// Returns:
     ///    str: The type of the measurement.
     pub fn measurement_type(&self) -> &'static str {
-        "BasisRotation"
+        "PauliZProduct"
     }
 
     /// Return clone of Measurement with symbolic parameters replaced.
@@ -192,39 +192,39 @@ impl BasisRotationWrapper {
     ///     ValueError: Cannot serialize Measurement to bytes.
     pub fn _internal_to_bincode(&self) -> PyResult<(&'static str, Py<PyByteArray>)> {
         let serialized = serialize(&self.internal).map_err(|_| {
-            PyValueError::new_err("Cannot serialize BasisRotationMeasurement to bytes")
+            PyValueError::new_err("Cannot serialize PauliZProductMeasurement to bytes")
         })?;
         let b: Py<PyByteArray> = Python::with_gil(|py| -> Py<PyByteArray> {
             PyByteArray::new(py, &serialized[..]).into()
         });
-        Ok(("BasisRotation", b))
+        Ok(("PauliZProduct", b))
     }
 
-    /// Serialize the BasisRotation to json form using the [serde_json] crate.
+    /// Serialize the PauliZProduct to json form using the [serde_json] crate.
     ///
     /// Returns:
-    ///     str: The serialized BasisRotation.
+    ///     str: The serialized PauliZProduct.
     ///
     /// Raises:
-    ///     RuntimeError: Unexpected error serializing BasisRotation.
+    ///     RuntimeError: Unexpected error serializing PauliZProduct.
     pub fn to_json(&self) -> PyResult<String> {
         serde_json::to_string(&self.internal)
-            .map_err(|_| PyRuntimeError::new_err("Unexpected error serializing BasisRotation"))
+            .map_err(|_| PyRuntimeError::new_err("Unexpected error serializing PauliZProduct"))
     }
 
-    /// Deserialize the BasisRotation from json form using the [serde_json] crate.
+    /// Deserialize the PauliZProduct from json form using the [serde_json] crate.
     ///
     /// Returns:
-    ///     BasisRotation: The deserialized BasisRotation.
+    ///     PauliZProduct: The deserialized PauliZProduct.
     ///
     /// Raises:
-    ///     RuntimeError: Cannot deserialize string to BasisRotation.
+    ///     RuntimeError: Cannot deserialize string to PauliZProduct.
     #[allow(unused_variables)]
     #[classmethod]
     pub fn from_json(cls: &PyType, json_string: &str) -> PyResult<Self> {
         Ok(Self {
             internal: serde_json::from_str(json_string)
-                .map_err(|_| PyValueError::new_err("Cannot deserialize string to BasisRotation"))?,
+                .map_err(|_| PyValueError::new_err("Cannot deserialize string to PauliZProduct"))?,
         })
     }
 }

--- a/qoqo/src/measurements/cheated_basis_rotation_measurement.rs
+++ b/qoqo/src/measurements/cheated_basis_rotation_measurement.rs
@@ -12,42 +12,42 @@
 
 //! Qoqo basis rotation measurement
 
-use super::CheatedBasisRotationInputWrapper;
+use super::CheatedPauliZProductInputWrapper;
 use crate::CircuitWrapper;
 use bincode::serialize;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyByteArray;
 use pyo3::types::PyType;
-use roqoqo::measurements::CheatedBasisRotation;
+use roqoqo::measurements::CheatedPauliZProduct;
 use roqoqo::prelude::*;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::Circuit;
 use std::collections::HashMap;
-#[pyclass(name = "CheatedBasisRotation", module = "qoqo.measurements")]
+#[pyclass(name = "CheatedPauliZProduct", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a basis rotation measurement.
-pub struct CheatedBasisRotationWrapper {
-    /// Internal storage of [roqoqo::BasisRotation].
-    pub internal: CheatedBasisRotation,
+pub struct CheatedPauliZProductWrapper {
+    /// Internal storage of [roqoqo::PauliZProduct].
+    pub internal: CheatedPauliZProduct,
 }
 
 #[pymethods]
-impl CheatedBasisRotationWrapper {
-    /// Creates an new BasisRotation measurement.
+impl CheatedPauliZProductWrapper {
+    /// Creates an new PauliZProduct measurement.
     ///
     /// Args:
     ///     constant_circuit (Optional[Circuit]): The constant Circuit that is executed before each Circuit in circuits.
     ///     circuits (list[Circuit]): The collection of quantum circuits for the separate basis rotations.
-    ///     input (CheatedBasisRotationInput): The additional input information required for measurement.
+    ///     input (CheatedPauliZProductInput): The additional input information required for measurement.
     ///
     /// Returns:
-    ///     self: The CheatedBasisRotation containing the new basis rotation measurement.
+    ///     self: The CheatedPauliZProduct containing the new basis rotation measurement.
     #[new]
     pub fn new(
         constant_circuit: Option<CircuitWrapper>,
         circuits: Vec<CircuitWrapper>,
-        input: CheatedBasisRotationInputWrapper,
+        input: CheatedPauliZProductInputWrapper,
     ) -> Self {
         let new_circuits: Vec<Circuit> = circuits.into_iter().map(|c| c.internal).collect();
         let new_constant: Option<Circuit> = match constant_circuit {
@@ -55,7 +55,7 @@ impl CheatedBasisRotationWrapper {
             Some(c) => Some(c.internal),
         };
         Self {
-            internal: CheatedBasisRotation {
+            internal: CheatedPauliZProduct {
                 constant_circuit: new_constant,
                 circuits: new_circuits,
                 input: input.internal,
@@ -148,10 +148,10 @@ impl CheatedBasisRotationWrapper {
     /// Returns the measurement input data defining how to construct expectation values from measurements.
     ///
     /// Returns:
-    ///     CheatedBasisRotationInput: The measurment input of CheatedBasisRotation.
-    pub fn input(&self) -> CheatedBasisRotationInputWrapper {
+    ///     CheatedPauliZProductInput: The measurment input of CheatedPauliZProduct.
+    pub fn input(&self) -> CheatedPauliZProductInputWrapper {
         let input = self.internal.input.clone();
-        CheatedBasisRotationInputWrapper { internal: input }
+        CheatedPauliZProductInputWrapper { internal: input }
     }
 
     /// Returns the type of the measurement in string form.
@@ -159,7 +159,7 @@ impl CheatedBasisRotationWrapper {
     /// Returns:
     ///    str: The type of the measurement.
     pub fn measurement_type(&self) -> &'static str {
-        "CheatedBasisRotation"
+        "CheatedPauliZProduct"
     }
 
     /// Returns clone of Measurement with symbolic parameters replaced
@@ -191,39 +191,39 @@ impl CheatedBasisRotationWrapper {
     ///     ValueError: Cannot serialize Measurement to bytes.
     pub fn _internal_to_bincode(&self) -> PyResult<(&'static str, Py<PyByteArray>)> {
         let serialized = serialize(&self.internal).map_err(|_| {
-            PyValueError::new_err("Cannot serialize CheatedBasisRotationMeasurement to bytes")
+            PyValueError::new_err("Cannot serialize CheatedPauliZProductMeasurement to bytes")
         })?;
         let b: Py<PyByteArray> = Python::with_gil(|py| -> Py<PyByteArray> {
             PyByteArray::new(py, &serialized[..]).into()
         });
-        Ok(("CheatedBasisRotation", b))
+        Ok(("CheatedPauliZProduct", b))
     }
 
-    /// Serializes the CheatedBasisRotation to json form using the [serde_json] crate.
+    /// Serializes the CheatedPauliZProduct to json form using the [serde_json] crate.
     ///
     /// Returns:
-    ///     str: The serialized CheatedBasisRotation.
+    ///     str: The serialized CheatedPauliZProduct.
     ///
     /// Raises:
-    ///     RuntimeError: Unexpected error serializing CheatedBasisRotation.
+    ///     RuntimeError: Unexpected error serializing CheatedPauliZProduct.
     pub fn to_json(&self) -> PyResult<String> {
         serde_json::to_string(&self.internal)
-            .map_err(|_| PyRuntimeError::new_err("Unexpected error serializing BasisRotation"))
+            .map_err(|_| PyRuntimeError::new_err("Unexpected error serializing PauliZProduct"))
     }
 
-    /// Deserialize the CheatedBasisRotation from json form using the [serde_json] crate.
+    /// Deserialize the CheatedPauliZProduct from json form using the [serde_json] crate.
     ///
     /// Returns:
-    ///     CheatedBasisRotation: the deserialized CheatedBasisRotation.
+    ///     CheatedPauliZProduct: the deserialized CheatedPauliZProduct.
     ///
     /// Raises:
-    ///     RuntimeError: Cannot deserialize string to CheatedBasisRotation.
+    ///     RuntimeError: Cannot deserialize string to CheatedPauliZProduct.
     #[allow(unused_variables)]
     #[classmethod]
     pub fn from_json(cls: &PyType, json_string: &str) -> PyResult<Self> {
         Ok(Self {
             internal: serde_json::from_str(json_string)
-                .map_err(|_| PyValueError::new_err("Cannot deserialize string to BasisRotation"))?,
+                .map_err(|_| PyValueError::new_err("Cannot deserialize string to PauliZProduct"))?,
         })
     }
 }

--- a/qoqo/src/measurements/measurement_auxiliary_data_input.rs
+++ b/qoqo/src/measurements/measurement_auxiliary_data_input.rs
@@ -16,43 +16,43 @@ use num_complex::Complex64;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use roqoqo::measurements::{
-    BasisRotationInput, CheatedBasisRotationInput, CheatedInput, PauliProductMask,
+    PauliZProductInput, CheatedPauliZProductInput, CheatedInput, PauliProductMask,
 };
 use std::collections::HashMap;
 
-#[pyclass(name = "BasisRotationInput", module = "qoqo.measurements")]
+#[pyclass(name = "PauliZProductInput", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
-/// Provides Necessary Information to run a [roqoqo::measurements::BasisRotation] measurement.
-pub struct BasisRotationInputWrapper {
-    /// Internal storage of [roqoqo::BasisRotationInput].
-    pub internal: BasisRotationInput,
+/// Provides Necessary Information to run a [roqoqo::measurements::PauliZProduct] measurement.
+pub struct PauliZProductInputWrapper {
+    /// Internal storage of [roqoqo::PauliZProductInput].
+    pub internal: PauliZProductInput,
 }
 
 #[pymethods]
-impl BasisRotationInputWrapper {
-    /// Create new BasisRotationInput.
+impl PauliZProductInputWrapper {
+    /// Create new PauliZProductInput.
     ///
-    /// The BasisRotationInput starts with just the number of qubtis and flipped measurements set.
+    /// The PauliZProductInput starts with just the number of qubtis and flipped measurements set.
     /// The pauli_poduct_qubit_masks and measured_exp_vals start empty
-    /// and can be extended with [BasisRotationInput::add_pauli_product]
-    /// [BasisRotationInput::add_linear_exp_val] and [BasisRotationInput::add_symbolic_exp_val]
+    /// and can be extended with [PauliZProductInput::add_pauliz_product]
+    /// [PauliZProductInput::add_linear_exp_val] and [PauliZProductInput::add_symbolic_exp_val]
     ///
     /// Args:
-    ///     number_qubits (int): The number of qubits in the BasisRotation measurement.
+    ///     number_qubits (int): The number of qubits in the PauliZProduct measurement.
     ///     use_flipped_measurement (bool): Whether or not to use flipped measurements.
     ///
     /// Returns:
-    ///     self: The new instance of BasisRotationInput with pauli_product_qubit_masks = an empty dictionary, the
+    ///     self: The new instance of PauliZProductInput with pauli_product_qubit_masks = an empty dictionary, the
     ///           specified number of qubits in input, number_pauli_products = 0, measured_exp_vals = an empty
     ///           dictionary, and whether to use flipped measurements as specified in input.
     #[new]
     pub fn new(number_qubits: usize, use_flipped_measurement: bool) -> Self {
         Self {
-            internal: BasisRotationInput::new(number_qubits, use_flipped_measurement),
+            internal: PauliZProductInput::new(number_qubits, use_flipped_measurement),
         }
     }
 
-    /// Add measured Pauli product to BasisRotationInput and returns index of Pauli product.
+    /// Add measured Pauli product to PauliZProductInput and returns index of Pauli product.
     ///
     /// When the pauli product is already in the measurement input the function only returns
     /// it index.
@@ -66,13 +66,13 @@ impl BasisRotationInputWrapper {
     ///
     /// Raises:
     ///     RuntimeError: Failed to add pauli product.
-    pub fn add_pauli_product(
+    pub fn add_pauliz_product(
         &mut self,
         readout: String,
         pauli_product_mask: PauliProductMask,
     ) -> PyResult<usize> {
         self.internal
-            .add_pauli_product(readout, pauli_product_mask)
+            .add_pauliz_product(readout, pauli_product_mask)
             .map_err(|_| PyRuntimeError::new_err("Failed to add pauli product"))
     }
 
@@ -121,41 +121,41 @@ impl BasisRotationInputWrapper {
     }
 }
 
-#[pyclass(name = "CheatedBasisRotationInput", module = "qoqo.measurements")]
+#[pyclass(name = "CheatedPauliZProductInput", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a cheated basis rotation measurement.
-pub struct CheatedBasisRotationInputWrapper {
-    /// Internal storage of [roqoqo::CheatedBasisRotationInput].
-    pub internal: CheatedBasisRotationInput,
+pub struct CheatedPauliZProductInputWrapper {
+    /// Internal storage of [roqoqo::CheatedPauliZProductInput].
+    pub internal: CheatedPauliZProductInput,
 }
 
-impl Default for CheatedBasisRotationInputWrapper {
+impl Default for CheatedPauliZProductInputWrapper {
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[pymethods]
-impl CheatedBasisRotationInputWrapper {
-    /// Create new CheatedBasisRotationInput.
+impl CheatedPauliZProductInputWrapper {
+    /// Create new CheatedPauliZProductInput.
     ///
-    /// The CheatedBasisRotationInput starts with just the number of qubtis and flipped measurements set.
+    /// The CheatedPauliZProductInput starts with just the number of qubtis and flipped measurements set.
     /// The pauli_poduct_qubit_masks and measured_exp_vals start empty
-    /// and can be extended with [CheatedBasisRotationInput::add_linear_exp_val] and
-    /// [CheatedBasisRotationInput::add_symbolic_exp_val].
+    /// and can be extended with [CheatedPauliZProductInput::add_linear_exp_val] and
+    /// [CheatedPauliZProductInput::add_symbolic_exp_val].
     ///
     /// Returns:
-    ///     self: The new instance of BasisRotationInput with pauli_product_qubit_masks = an empty dictionary, the
+    ///     self: The new instance of PauliZProductInput with pauli_product_qubit_masks = an empty dictionary, the
     ///           specified number of qubits in input, number_pauli_products = 0, measured_exp_vals = an empty
     ///           dictionary, and whether to use flipped measurements as specified in input.
     #[new]
     pub fn new() -> Self {
         Self {
-            internal: CheatedBasisRotationInput::new(),
+            internal: CheatedPauliZProductInput::new(),
         }
     }
 
-    /// Add measured Pauli product to CheatedBasisRotationInput and returns index of Pauli product.
+    /// Add measured Pauli product to CheatedPauliZProductInput and returns index of Pauli product.
     ///
     /// When the pauli product is already in the measurement input the function only returns
     /// its index.
@@ -165,8 +165,8 @@ impl CheatedBasisRotationInputWrapper {
     ///
     /// Returns:
     ///     int: The index of the added Pauli product in the list of all Pauli products.
-    pub fn add_pauli_product(&mut self, readout: String) -> usize {
-        self.internal.add_pauli_product(readout)
+    pub fn add_pauliz_product(&mut self, readout: String) -> usize {
+        self.internal.add_pauliz_product(readout)
     }
 
     /// Add linear definition of expectation value to measurement input.
@@ -233,7 +233,7 @@ impl CheatedInputWrapper {
     /// of an operator matrix.
     ///
     /// Args:
-    ///     number_qubits (int): The number of qubits in the BasisRotation measurement.
+    ///     number_qubits (int): The number of qubits in the PauliZProduct measurement.
     ///
     /// Returns:
     ///     CheatedInput: The new instance of CheatedInput with the specified number of qubits in input,

--- a/qoqo/src/measurements/measurement_auxiliary_data_input.rs
+++ b/qoqo/src/measurements/measurement_auxiliary_data_input.rs
@@ -16,7 +16,7 @@ use num_complex::Complex64;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use roqoqo::measurements::{
-    PauliZProductInput, CheatedPauliZProductInput, CheatedInput, PauliProductMask,
+    CheatedInput, CheatedPauliZProductInput, PauliProductMask, PauliZProductInput,
 };
 use std::collections::HashMap;
 

--- a/qoqo/src/measurements/mod.rs
+++ b/qoqo/src/measurements/mod.rs
@@ -15,12 +15,12 @@
 use pyo3::prelude::*;
 mod measurement_auxiliary_data_input;
 pub use measurement_auxiliary_data_input::{
-    BasisRotationInputWrapper, CheatedBasisRotationInputWrapper, CheatedInputWrapper,
+    PauliZProductInputWrapper, CheatedPauliZProductInputWrapper, CheatedInputWrapper,
 };
 mod basis_rotation_measurement;
-pub use basis_rotation_measurement::BasisRotationWrapper;
+pub use basis_rotation_measurement::PauliZProductWrapper;
 mod cheated_basis_rotation_measurement;
-pub use cheated_basis_rotation_measurement::CheatedBasisRotationWrapper;
+pub use cheated_basis_rotation_measurement::CheatedPauliZProductWrapper;
 mod cheated_measurement;
 pub use cheated_measurement::CheatedWrapper;
 mod classical_register_measurement;
@@ -29,11 +29,11 @@ pub use classical_register_measurement::ClassicalRegisterWrapper;
 /// Measurements
 #[pymodule]
 pub fn measurements(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<BasisRotationInputWrapper>()?;
-    m.add_class::<CheatedBasisRotationInputWrapper>()?;
+    m.add_class::<PauliZProductInputWrapper>()?;
+    m.add_class::<CheatedPauliZProductInputWrapper>()?;
     m.add_class::<CheatedInputWrapper>()?;
-    m.add_class::<BasisRotationWrapper>()?;
-    m.add_class::<CheatedBasisRotationWrapper>()?;
+    m.add_class::<PauliZProductWrapper>()?;
+    m.add_class::<CheatedPauliZProductWrapper>()?;
     m.add_class::<CheatedWrapper>()?;
     m.add_class::<ClassicalRegisterWrapper>()?;
 

--- a/qoqo/src/measurements/mod.rs
+++ b/qoqo/src/measurements/mod.rs
@@ -15,7 +15,7 @@
 use pyo3::prelude::*;
 mod measurement_auxiliary_data_input;
 pub use measurement_auxiliary_data_input::{
-    PauliZProductInputWrapper, CheatedPauliZProductInputWrapper, CheatedInputWrapper,
+    CheatedInputWrapper, CheatedPauliZProductInputWrapper, PauliZProductInputWrapper,
 };
 mod basis_rotation_measurement;
 pub use basis_rotation_measurement::PauliZProductWrapper;

--- a/qoqo/src/quantum_program.rs
+++ b/qoqo/src/quantum_program.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 
 use crate::measurements::{
-    PauliZProductWrapper, CheatedPauliZProductWrapper, CheatedWrapper, ClassicalRegisterWrapper,
+    CheatedPauliZProductWrapper, CheatedWrapper, ClassicalRegisterWrapper, PauliZProductWrapper,
 };
 use crate::{QoqoError, QOQO_VERSION};
 use bincode::{deserialize, serialize};

--- a/qoqo/src/quantum_program.rs
+++ b/qoqo/src/quantum_program.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 
 use crate::measurements::{
-    BasisRotationWrapper, CheatedBasisRotationWrapper, CheatedWrapper, ClassicalRegisterWrapper,
+    PauliZProductWrapper, CheatedPauliZProductWrapper, CheatedWrapper, ClassicalRegisterWrapper,
 };
 use crate::{QoqoError, QOQO_VERSION};
 use bincode::{deserialize, serialize};
@@ -59,17 +59,17 @@ impl QuantumProgramWrapper {
     ///     self: The new .
     #[new]
     pub fn new(measurement: &PyAny, input_parameter_names: Vec<String>) -> PyResult<Self> {
-        if let Ok(try_downcast) = measurement.extract::<BasisRotationWrapper>() {
+        if let Ok(try_downcast) = measurement.extract::<PauliZProductWrapper>() {
             return Ok(Self {
-                internal: QuantumProgram::BasisRotation {
+                internal: QuantumProgram::PauliZProduct {
                     measurement: try_downcast.internal,
                     input_parameter_names,
                 },
             });
         }
-        if let Ok(try_downcast) = measurement.extract::<CheatedBasisRotationWrapper>() {
+        if let Ok(try_downcast) = measurement.extract::<CheatedPauliZProductWrapper>() {
             return Ok(Self {
-                internal: QuantumProgram::CheatedBasisRotation {
+                internal: QuantumProgram::CheatedPauliZProduct {
                     measurement: try_downcast.internal,
                     input_parameter_names,
                 },
@@ -100,13 +100,13 @@ impl QuantumProgramWrapper {
             .extract::<(&str, &[u8])>()
             .map_err(|_| PyTypeError::new_err("measurement is not of type Measurement. Are you using different versions of roqoqo?"))?;
         match name {
-            "BasisRotation" => {
-                let measure: measurements::BasisRotation = deserialize(encoded).map_err(|_| PyTypeError::new_err("measurement is not of type Measurement. Are you using different versions of roqoqo?"))?;
-                Ok( Self{internal: QuantumProgram::BasisRotation{measurement: measure, input_parameter_names}})
+            "PauliZProduct" => {
+                let measure: measurements::PauliZProduct = deserialize(encoded).map_err(|_| PyTypeError::new_err("measurement is not of type Measurement. Are you using different versions of roqoqo?"))?;
+                Ok( Self{internal: QuantumProgram::PauliZProduct{measurement: measure, input_parameter_names}})
             },
-            "CheatedBasisRotation" => {
-                let measure: measurements::CheatedBasisRotation = deserialize(encoded).map_err(|_| PyTypeError::new_err("measurement is not of type Measurement. Are you using different versions of roqoqo?"))?;
-                Ok( Self{internal: QuantumProgram::CheatedBasisRotation{measurement: measure, input_parameter_names}})
+            "CheatedPauliZProduct" => {
+                let measure: measurements::CheatedPauliZProduct = deserialize(encoded).map_err(|_| PyTypeError::new_err("measurement is not of type Measurement. Are you using different versions of roqoqo?"))?;
+                Ok( Self{internal: QuantumProgram::CheatedPauliZProduct{measurement: measure, input_parameter_names}})
             },
             "Cheated" => {
                 let measure: measurements::Cheated = deserialize(encoded).map_err(|_| PyTypeError::new_err("measurement is not of type Measurement. Are you using different versions of roqoqo?"))?;
@@ -124,29 +124,29 @@ impl QuantumProgramWrapper {
     ///
     /// Returns:
     ///     PyObject corresponding to the qoqo measurement type of the QuantumProgram,
-    ///     i.e. BasisRotation, CheatedBasisRotation, Cheated or ClassicalRegister.
+    ///     i.e. PauliZProduct, CheatedPauliZProduct, Cheated or ClassicalRegister.
     pub fn measurement(&self) -> PyObject {
         match self.internal.clone() {
-            QuantumProgram::BasisRotation {
+            QuantumProgram::PauliZProduct {
                 measurement,
                 input_parameter_names: _,
             } => Python::with_gil(|py| -> PyObject {
-                let pyref: Py<BasisRotationWrapper> = Py::new(
+                let pyref: Py<PauliZProductWrapper> = Py::new(
                     py,
-                    BasisRotationWrapper {
+                    PauliZProductWrapper {
                         internal: measurement.clone(),
                     },
                 )
                 .unwrap();
                 pyref.to_object(py)
             }),
-            QuantumProgram::CheatedBasisRotation {
+            QuantumProgram::CheatedPauliZProduct {
                 measurement,
                 input_parameter_names: _,
             } => Python::with_gil(|py| -> PyObject {
-                let pyref: Py<CheatedBasisRotationWrapper> = Py::new(
+                let pyref: Py<CheatedPauliZProductWrapper> = Py::new(
                     py,
-                    CheatedBasisRotationWrapper {
+                    CheatedPauliZProductWrapper {
                         internal: measurement.clone(),
                     },
                 )
@@ -188,11 +188,11 @@ impl QuantumProgramWrapper {
     ///     List of input parameter names.
     pub fn input_parameter_names(&self) -> Vec<String> {
         match self.internal.clone() {
-            QuantumProgram::BasisRotation {
+            QuantumProgram::PauliZProduct {
                 measurement: _,
                 input_parameter_names,
             } => input_parameter_names,
-            QuantumProgram::CheatedBasisRotation {
+            QuantumProgram::CheatedPauliZProduct {
                 measurement: _,
                 input_parameter_names,
             } => input_parameter_names,
@@ -218,23 +218,23 @@ impl QuantumProgramWrapper {
     pub fn run(&self, backend: Py<PyAny>, parameters: Option<Vec<f64>>) -> PyResult<Py<PyAny>> {
         let parameters = parameters.unwrap_or_default();
         match &self.internal{
-            QuantumProgram::BasisRotation{measurement, input_parameter_names } => {
+            QuantumProgram::PauliZProduct{measurement, input_parameter_names } => {
                 if parameters.len() != input_parameter_names.len() { return Err(PyValueError::new_err( format!("Wrong number of parameters {} parameters expected {} parameters given", input_parameter_names.len(), parameters.len())))};
                 let substituted_parameters: HashMap<String, f64> = input_parameter_names.iter().zip(parameters.iter()).map(|(key, value)| (key.clone(), *value)).collect();
                 let substituted_measurement = measurement.substitute_parameters(
                     substituted_parameters
                 ).map_err(|err| PyRuntimeError::new_err(format!("Applying parameters failed {:?}", err)))?;
                 Python::with_gil(|py| -> PyResult<Py<PyAny>> {
-                    backend.call_method1(py, "run_measurement", (BasisRotationWrapper{internal: substituted_measurement}, ))
+                    backend.call_method1(py, "run_measurement", (PauliZProductWrapper{internal: substituted_measurement}, ))
                 })            }
-            QuantumProgram::CheatedBasisRotation{measurement, input_parameter_names } => {
+            QuantumProgram::CheatedPauliZProduct{measurement, input_parameter_names } => {
                 if parameters.len() != input_parameter_names.len() { return Err(PyValueError::new_err( format!("Wrong number of parameters {} parameters expected {} parameters given", input_parameter_names.len(), parameters.len())))};
                 let substituted_parameters: HashMap<String, f64> = input_parameter_names.iter().zip(parameters.iter()).map(|(key, value)| (key.clone(), *value)).collect();
                 let substituted_measurement = measurement.substitute_parameters(
                     substituted_parameters
                 ).map_err(|err| PyRuntimeError::new_err(format!("Applying parameters failed {:?}", err)))?;
                 Python::with_gil(|py| -> PyResult<Py<PyAny>> {
-                    backend.call_method1(py, "run_measurement", (CheatedBasisRotationWrapper{internal: substituted_measurement}, ))
+                    backend.call_method1(py, "run_measurement", (CheatedPauliZProductWrapper{internal: substituted_measurement}, ))
                 })
             }
             QuantumProgram::Cheated{measurement, input_parameter_names } => {

--- a/qoqo/tests/integration/circuit.rs
+++ b/qoqo/tests/integration/circuit.rs
@@ -12,7 +12,7 @@
 
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
-use qoqo::measurements::{BasisRotationInputWrapper, BasisRotationWrapper};
+use qoqo::measurements::{PauliZProductInputWrapper, PauliZProductWrapper};
 use qoqo::operations::{
     convert_operation_to_pyobject, PragmaOverrotationWrapper, RotateXWrapper, RotateYWrapper,
 };
@@ -320,24 +320,24 @@ fn test_to_from_bincode() {
 fn test_value_error_bincode() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let new_br = &(*br);
@@ -345,7 +345,7 @@ fn test_value_error_bincode() {
         let deserialised = new_br
             .call_method1("from_json", (serialised,))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let new = new_circuit(py);

--- a/qoqo/tests/integration/measurements/basis_rotation_measurement.rs
+++ b/qoqo/tests/integration/measurements/basis_rotation_measurement.rs
@@ -15,11 +15,11 @@
 use bincode::serialize;
 use pyo3::prelude::*;
 use pyo3::Python;
-use qoqo::measurements::{BasisRotationInputWrapper, BasisRotationWrapper};
+use qoqo::measurements::{PauliZProductInputWrapper, PauliZProductWrapper};
 use qoqo::CircuitWrapper;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::{
-    measurements::{BasisRotation, BasisRotationInput},
+    measurements::{PauliZProduct, PauliZProductInput},
     Circuit,
 };
 use std::collections::HashMap;
@@ -29,32 +29,32 @@ use test_case::test_case;
 fn test_returning_circuits() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0, 1]))
+            .call_method1("add_pauliz_product", ("ro", vec![0, 1]))
             .unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, 0.0.into());
         circs.push(circ1);
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let circuits: Vec<CircuitWrapper> = br.call_method0("circuits").unwrap().extract().unwrap();
@@ -70,7 +70,7 @@ fn test_returning_circuits() {
     })
 }
 
-/// Test evaluate() function for BasisRotation measurement
+/// Test evaluate() function for PauliZProduct measurement
 #[test_case(vec![
     vec![false, false, false],
     vec![false, false, false],
@@ -103,24 +103,24 @@ fn test_py03_evaluate_bool(
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("ro", vec![1, 2]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("rx", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("rx", vec![1, 2]))
             .unwrap();
 
         let mut linear_map: HashMap<usize, f64> = HashMap::new();
@@ -159,11 +159,11 @@ fn test_py03_evaluate_bool(
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let mut measured_registers: HashMap<String, BitOutputRegister> = HashMap::new();
@@ -200,7 +200,7 @@ fn test_py03_evaluate_bool(
     })
 }
 
-/// Test evaluate() function for BasisRotation measurement with usize in register
+/// Test evaluate() function for PauliZProduct measurement with usize in register
 #[test_case(vec![
     vec![1, 1, 0],
     vec![1, 1, 0],
@@ -217,24 +217,24 @@ fn test_py03_evaluate_usize(
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("ro", vec![1, 2]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("rx", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("rx", vec![1, 2]))
             .unwrap();
 
         let mut linear_map: HashMap<usize, f64> = HashMap::new();
@@ -273,11 +273,11 @@ fn test_py03_evaluate_usize(
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let mut measured_registers: HashMap<String, Vec<Vec<usize>>> = HashMap::new();
@@ -309,7 +309,7 @@ fn test_py03_evaluate_usize(
     })
 }
 
-/// Test evaluate() function for BasisRotation measurement with symbolic parameters
+/// Test evaluate() function for PauliZProduct measurement with symbolic parameters
 #[test_case(vec![
     vec![false, false, false],
     vec![false, false, false],
@@ -324,24 +324,24 @@ fn test_evaluate_symbolic(register: Vec<Vec<bool>>, constant: f64) {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("ro", vec![1, 2]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("rx", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("rx", vec![1, 2]))
             .unwrap();
 
         let symbolic_pystring =
@@ -355,11 +355,11 @@ fn test_evaluate_symbolic(register: Vec<Vec<bool>>, constant: f64) {
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let mut measured_registers: HashMap<String, BitOutputRegister> = HashMap::new();
@@ -393,33 +393,33 @@ fn test_py03_evaluate_error0() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("ro", vec![1, 2]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("rx", vec![1, 2]))
+            .call_method1("add_pauliz_product", ("rx", vec![1, 2]))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let measured_registers: HashMap<String, BitOutputRegister> = HashMap::new();
@@ -446,32 +446,32 @@ fn test_pyo3_copy() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0, 1]))
+            .call_method1("add_pauliz_product", ("ro", vec![0, 1]))
             .unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, 0.0.into());
         circs.push(circ1);
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
         let br_clone = &(*br);
 
@@ -503,34 +503,34 @@ fn test_pyo3_debug() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
-        let br_wrapper = br.extract::<BasisRotationWrapper>().unwrap();
+        let br_wrapper = br.extract::<PauliZProductWrapper>().unwrap();
 
         let br_clone = br_wrapper.clone();
         assert_eq!(format!("{:?}", br_wrapper), format!("{:?}", br_clone));
 
-        let debug_string = "RefCell { value: BasisRotationWrapper { internal: BasisRotation { constant_circuit: Some(Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }), circuits: [Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }], input: BasisRotationInput { pauli_product_qubit_masks: {\"ro\": {0: []}}, number_qubits: 3, number_pauli_products: 1, measured_exp_vals: {}, use_flipped_measurement: false } } } }";
+        let debug_string = "RefCell { value: PauliZProductWrapper { internal: PauliZProduct { constant_circuit: Some(Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }), circuits: [Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }], input: PauliZProductInput { pauli_product_qubit_masks: {\"ro\": {0: []}}, number_qubits: 3, number_pauli_products: 1, measured_exp_vals: {}, use_flipped_measurement: false } } } }";
         assert_eq!(format!("{:?}", br), debug_string);
 
-        let debug_input_string = "RefCell { value: BasisRotationInputWrapper { internal: BasisRotationInput { pauli_product_qubit_masks: {\"ro\": {0: []}}, number_qubits: 3, number_pauli_products: 1, measured_exp_vals: {}, use_flipped_measurement: false } } }";
+        let debug_input_string = "RefCell { value: PauliZProductInputWrapper { internal: PauliZProductInput { pauli_product_qubit_masks: {\"ro\": {0: []}}, number_qubits: 3, number_pauli_products: 1, measured_exp_vals: {}, use_flipped_measurement: false } } }";
         assert_eq!(format!("{:?}", input), debug_input_string);
 
         let debug_input = &(*input);
@@ -549,7 +549,7 @@ fn test_pyo3_debug() {
             debug_input.call_method1("add_symbolic_exp_val", ("single_pp_val", symbolic_pystring));
         assert!(error.is_err());
 
-        let error = debug_input.call_method1("add_pauli_product", ("ro", vec![4]));
+        let error = debug_input.call_method1("add_pauliz_product", ("ro", vec![4]));
         assert!(error.is_err());
     })
 }
@@ -559,32 +559,32 @@ fn test_pyo3_debug() {
 fn test_internal_to_bincode() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec.clone()))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec.clone()))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
-        let mut roqoqo_bri = BasisRotationInput::new(3, false);
+        let mut roqoqo_bri = PauliZProductInput::new(3, false);
         roqoqo_bri
-            .add_pauli_product("ro".to_string(), tmp_vec)
+            .add_pauliz_product("ro".to_string(), tmp_vec)
             .unwrap();
         let circs: Vec<Circuit> = vec![Circuit::new()];
-        let roqoqo_br = BasisRotation {
+        let roqoqo_br = PauliZProduct {
             constant_circuit: Some(Circuit::new()),
             circuits: circs,
             input: roqoqo_bri,
@@ -596,7 +596,7 @@ fn test_internal_to_bincode() {
             .unwrap()
             .extract()
             .unwrap();
-        assert_eq!(serialised.0, "BasisRotation");
+        assert_eq!(serialised.0, "PauliZProduct");
         assert_eq!(serialised.1, comparison_serialised);
     })
 }
@@ -607,24 +607,24 @@ fn test_to_from_json() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let new_br = &(*br);
@@ -632,7 +632,7 @@ fn test_to_from_json() {
         let deserialised = new_br
             .call_method1("from_json", (serialised,))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
         assert_eq!(format!("{:?}", br), format!("{:?}", deserialised));
 
@@ -655,32 +655,32 @@ fn test_substitute_parameters() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0, 1]))
+            .call_method1("add_pauliz_product", ("ro", vec![0, 1]))
             .unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, "theta".into());
         circs.push(circ1);
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let mut map: HashMap<String, f64> = HashMap::<String, f64>::new();
@@ -688,11 +688,11 @@ fn test_substitute_parameters() {
         let br_sub = br
             .call_method1("substitute_parameters", (map,))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
-        let br_wrapper = br.extract::<BasisRotationWrapper>().unwrap();
-        let br_sub_wrapper = br_sub.extract::<BasisRotationWrapper>().unwrap();
+        let br_wrapper = br.extract::<PauliZProductWrapper>().unwrap();
+        let br_sub_wrapper = br_sub.extract::<PauliZProductWrapper>().unwrap();
         assert_ne!(format!("{:?}", br_wrapper), format!("{:?}", br_sub_wrapper));
     })
 }
@@ -703,32 +703,32 @@ fn test_substitute_parameters_error() {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0]))
+            .call_method1("add_pauliz_product", ("ro", vec![0]))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", vec![0, 1]))
+            .call_method1("add_pauliz_product", ("ro", vec![0, 1]))
             .unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, "theta".into());
         circs.push(circ1);
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let map: HashMap<String, f64> = HashMap::<String, f64>::new();
@@ -741,28 +741,28 @@ fn test_substitute_parameters_error() {
 #[test]
 fn test_measurement_type() {
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec.clone()))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec.clone()))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let measurement_type = br.call_method0("measurement_type").unwrap();
-        assert_eq!(measurement_type.to_string(), "BasisRotation");
+        assert_eq!(measurement_type.to_string(), "PauliZProduct");
     })
 }
 
@@ -770,30 +770,30 @@ fn test_measurement_type() {
 #[test]
 fn test_return_input() {
     Python::with_gil(|py| {
-        let input_type = py.get_type::<BasisRotationInputWrapper>();
+        let input_type = py.get_type::<PauliZProductInputWrapper>();
         let input = input_type
             .call1((3, false))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
         let tmp_vec: Vec<usize> = Vec::new();
         let _ = input
-            .call_method1("add_pauli_product", ("ro", tmp_vec.clone()))
+            .call_method1("add_pauliz_product", ("ro", tmp_vec.clone()))
             .unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<BasisRotationWrapper>();
+        let br_type = py.get_type::<PauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<BasisRotationWrapper>>()
+            .cast_as::<PyCell<PauliZProductWrapper>>()
             .unwrap();
 
         let input_returned = br
             .call_method0("input")
             .unwrap()
-            .cast_as::<PyCell<BasisRotationInputWrapper>>()
+            .cast_as::<PyCell<PauliZProductInputWrapper>>()
             .unwrap();
 
         assert_eq!(format!("{:?}", input_returned), format!("{:?}", input));

--- a/qoqo/tests/integration/measurements/cheated_basis_rotation_measurement.rs
+++ b/qoqo/tests/integration/measurements/cheated_basis_rotation_measurement.rs
@@ -15,11 +15,11 @@
 use bincode::serialize;
 use pyo3::prelude::*;
 use pyo3::Python;
-use qoqo::measurements::{CheatedBasisRotationInputWrapper, CheatedBasisRotationWrapper};
+use qoqo::measurements::{CheatedPauliZProductInputWrapper, CheatedPauliZProductWrapper};
 use qoqo::CircuitWrapper;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::{
-    measurements::{CheatedBasisRotation, CheatedBasisRotationInput},
+    measurements::{CheatedPauliZProduct, CheatedPauliZProductInput},
     Circuit,
 };
 use std::collections::HashMap;
@@ -29,23 +29,23 @@ fn test_returning_circuits() {
     Python::with_gil(|py| {
         pyo3::prepare_freethreaded_python();
 
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, 0.0.into());
         circs.push(circ1);
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let circuits: Vec<CircuitWrapper> = br.call_method0("circuits").unwrap().extract().unwrap();
@@ -61,25 +61,25 @@ fn test_returning_circuits() {
     })
 }
 
-/// Test evaluate() function for CheatedBasisRotation measurement
+/// Test evaluate() function for CheatedPauliZProduct measurement
 #[test]
 fn test_py03_evaluate_bool() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_0",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_0",))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_1",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_1",))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_2",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_2",))
             .unwrap();
 
         let mut linear_map: HashMap<usize, f64> = HashMap::new();
@@ -97,11 +97,11 @@ fn test_py03_evaluate_bool() {
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let mut measured_registers: HashMap<String, FloatOutputRegister> = HashMap::new();
@@ -124,25 +124,25 @@ fn test_py03_evaluate_bool() {
     })
 }
 
-/// Test evaluate() function for CheatedBasisRotation measurement with symbolic parameters
+/// Test evaluate() function for CheatedPauliZProduct measurement with symbolic parameters
 #[test]
 fn test_evaluate_symbolic() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_0",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_0",))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_1",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_1",))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_2",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_2",))
             .unwrap();
 
         let symbolic_pystring =
@@ -153,11 +153,11 @@ fn test_evaluate_symbolic() {
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let mut measured_registers: HashMap<String, FloatOutputRegister> = HashMap::new();
@@ -183,20 +183,20 @@ fn test_evaluate_symbolic() {
 fn test_py03_evaluate_error0() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_0",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_0",))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_1",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_1",))
             .unwrap();
         let _ = input
-            .call_method1("add_pauli_product", ("ro_pauli_product_2",))
+            .call_method1("add_pauliz_product", ("ro_pauli_product_2",))
             .unwrap();
 
         let symbolic_pystring =
@@ -207,11 +207,11 @@ fn test_py03_evaluate_error0() {
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let input2: HashMap<String, FloatOutputRegister> =
@@ -234,23 +234,23 @@ fn test_py03_evaluate_error0() {
 fn test_pyo3_copy() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, 0.0.into());
         circs.push(circ1);
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
         let br_clone = &(*br);
 
@@ -281,36 +281,36 @@ fn test_pyo3_copy() {
 fn test_pyo3_debug() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
-        let br_wrapper = br.extract::<CheatedBasisRotationWrapper>().unwrap();
+        let br_wrapper = br.extract::<CheatedPauliZProductWrapper>().unwrap();
 
         let br_clone = br_wrapper.clone();
         assert_eq!(format!("{:?}", br_wrapper), format!("{:?}", br_clone));
 
-        let debug_string = "RefCell { value: CheatedBasisRotationWrapper { internal: CheatedBasisRotation { constant_circuit: Some(Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }), circuits: [Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }], input: CheatedBasisRotationInput { measured_exp_vals: {}, pauli_product_keys: {\"ro\": 0} } } } }";
+        let debug_string = "RefCell { value: CheatedPauliZProductWrapper { internal: CheatedPauliZProduct { constant_circuit: Some(Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }), circuits: [Circuit { definitions: [], operations: [], _roqoqo_version: RoqoqoVersion }], input: CheatedPauliZProductInput { measured_exp_vals: {}, pauli_product_keys: {\"ro\": 0} } } } }";
         assert_eq!(format!("{:?}", br), debug_string);
 
         let debug_input = &(*input);
-        let debug_input_string = "RefCell { value: CheatedBasisRotationInputWrapper { internal: CheatedBasisRotationInput { measured_exp_vals: {}, pauli_product_keys: {\"ro\": 0} } } }";
+        let debug_input_string = "RefCell { value: CheatedPauliZProductInputWrapper { internal: CheatedPauliZProductInput { measured_exp_vals: {}, pauli_product_keys: {\"ro\": 0} } } }";
         assert_eq!(format!("{:?}", input), debug_input_string);
         assert_eq!(
-            CheatedBasisRotationInputWrapper::default().internal,
-            CheatedBasisRotationInputWrapper::new().internal
+            CheatedPauliZProductInputWrapper::default().internal,
+            CheatedPauliZProductInputWrapper::new().internal
         );
 
         let mut linear_map: HashMap<usize, f64> = HashMap::new();
@@ -334,27 +334,27 @@ fn test_pyo3_debug() {
 fn test_internal_to_bincode() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
-        let mut roqoqo_bri = CheatedBasisRotationInput::new();
-        roqoqo_bri.add_pauli_product("ro".to_string());
+        let mut roqoqo_bri = CheatedPauliZProductInput::new();
+        roqoqo_bri.add_pauliz_product("ro".to_string());
         let circs: Vec<Circuit> = vec![Circuit::new()];
-        let roqoqo_br = CheatedBasisRotation {
+        let roqoqo_br = CheatedPauliZProduct {
             constant_circuit: Some(Circuit::new()),
             circuits: circs,
             input: roqoqo_bri,
@@ -366,7 +366,7 @@ fn test_internal_to_bincode() {
             .unwrap()
             .extract()
             .unwrap();
-        assert_eq!(serialised.0, "CheatedBasisRotation");
+        assert_eq!(serialised.0, "CheatedPauliZProduct");
         assert_eq!(serialised.1, comparison_serialised);
     })
 }
@@ -376,21 +376,21 @@ fn test_internal_to_bincode() {
 fn test_to_from_json() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
 
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs, input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let new_br = &(*br);
@@ -398,7 +398,7 @@ fn test_to_from_json() {
         let deserialised = new_br
             .call_method1("from_json", (serialised,))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
         assert_eq!(format!("{:?}", br), format!("{:?}", deserialised));
 
@@ -420,23 +420,23 @@ fn test_to_from_json() {
 fn test_substitute_parameters() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, "theta".into());
         circs.push(circ1);
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let mut map: HashMap<String, f64> = HashMap::<String, f64>::new();
@@ -444,11 +444,11 @@ fn test_substitute_parameters() {
         let br_sub = br
             .call_method1("substitute_parameters", (map,))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
-        let br_wrapper = br.extract::<CheatedBasisRotationWrapper>().unwrap();
-        let br_sub_wrapper = br_sub.extract::<CheatedBasisRotationWrapper>().unwrap();
+        let br_wrapper = br.extract::<CheatedPauliZProductWrapper>().unwrap();
+        let br_sub_wrapper = br_sub.extract::<CheatedPauliZProductWrapper>().unwrap();
         assert_ne!(format!("{:?}", br_wrapper), format!("{:?}", br_sub_wrapper));
     })
 }
@@ -458,23 +458,23 @@ fn test_substitute_parameters() {
 fn test_substitute_parameters_error() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, "theta".into());
         circs.push(circ1);
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let map: HashMap<String, f64> = HashMap::<String, f64>::new();
@@ -487,27 +487,27 @@ fn test_substitute_parameters_error() {
 #[test]
 fn test_measurement_type() {
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, "theta".into());
         circs.push(circ1);
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let measurement_type = br.call_method0("measurement_type").unwrap();
-        assert_eq!(measurement_type.to_string(), "CheatedBasisRotation");
+        assert_eq!(measurement_type.to_string(), "CheatedPauliZProduct");
     })
 }
 
@@ -515,29 +515,29 @@ fn test_measurement_type() {
 #[test]
 fn test_return_input() {
     Python::with_gil(|py| {
-        let input_type = py.get_type::<CheatedBasisRotationInputWrapper>();
+        let input_type = py.get_type::<CheatedPauliZProductInputWrapper>();
         let input = input_type
             .call0()
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
-        let _ = input.call_method1("add_pauli_product", ("ro",)).unwrap();
+        let _ = input.call_method1("add_pauliz_product", ("ro",)).unwrap();
 
         let mut circs: Vec<CircuitWrapper> = vec![CircuitWrapper::new()];
         let mut circ1 = CircuitWrapper::new();
         circ1.internal += roqoqo::operations::RotateX::new(0, "theta".into());
         circs.push(circ1);
-        let br_type = py.get_type::<CheatedBasisRotationWrapper>();
+        let br_type = py.get_type::<CheatedPauliZProductWrapper>();
         let br = br_type
             .call1((Some(CircuitWrapper::new()), circs.clone(), input))
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductWrapper>>()
             .unwrap();
 
         let input_returned = br
             .call_method0("input")
             .unwrap()
-            .cast_as::<PyCell<CheatedBasisRotationInputWrapper>>()
+            .cast_as::<PyCell<CheatedPauliZProductInputWrapper>>()
             .unwrap();
 
         assert_eq!(format!("{:?}", input_returned), format!("{:?}", input));

--- a/qoqo/tests/integration/quantum_program.rs
+++ b/qoqo/tests/integration/quantum_program.rs
@@ -13,16 +13,16 @@
 use num_complex::Complex64;
 use pyo3::prelude::*;
 use qoqo::measurements::{
-    PauliZProductInputWrapper, PauliZProductWrapper, CheatedPauliZProductInputWrapper,
-    CheatedPauliZProductWrapper, CheatedInputWrapper, CheatedWrapper, ClassicalRegisterWrapper,
+    CheatedInputWrapper, CheatedPauliZProductInputWrapper, CheatedPauliZProductWrapper,
+    CheatedWrapper, ClassicalRegisterWrapper, PauliZProductInputWrapper, PauliZProductWrapper,
 };
 use qoqo::operations::convert_operation_to_pyobject;
 use qoqo::{
     convert_into_quantum_program, CircuitWrapper, QoqoError, QuantumProgramWrapper, QOQO_VERSION,
 };
 use roqoqo::measurements::{
-    PauliZProduct, PauliZProductInput, Cheated, CheatedPauliZProduct, CheatedPauliZProductInput,
-    CheatedInput, ClassicalRegister,
+    Cheated, CheatedInput, CheatedPauliZProduct, CheatedPauliZProductInput, ClassicalRegister,
+    PauliZProduct, PauliZProductInput,
 };
 use roqoqo::operations::Operation;
 use roqoqo::operations::*;

--- a/roqoqo-test/src/stochastic_gate_test.rs
+++ b/roqoqo-test/src/stochastic_gate_test.rs
@@ -25,7 +25,7 @@ use roqoqo::operations::{
 };
 use roqoqo::prelude::*;
 use roqoqo::{
-    measurements::{BasisRotation, BasisRotationInput},
+    measurements::{PauliZProduct, PauliZProductInput},
     operations::*,
     Circuit,
 };
@@ -51,7 +51,7 @@ pub fn prepare_monte_carlo_gate_test(
     two_qubit_gate: Option<TwoQubitGateOperation>,
     number_stochastic_tests: usize,
     number_projective_measurement: usize,
-) -> (BasisRotation, HashMap<String, f64>) {
+) -> (PauliZProduct, HashMap<String, f64>) {
     if let Some(x) = two_qubit_gate {
         if !(x.control() == &0 && x.target() == &1 || x.control() == &1 && x.target() == &0) {
             panic!("Provided two_qubit_gate does not act on qubits 0 and 1")
@@ -73,7 +73,7 @@ pub fn prepare_monte_carlo_gate_test(
     starting_vec[1] = Complex::<f64>::new(1.0, 0.0);
 
     let mut expected_values: HashMap<String, f64> = HashMap::new();
-    let mut measurement_input = BasisRotationInput::new(number_qubits, false);
+    let mut measurement_input = PauliZProductInput::new(number_qubits, false);
     let mut measurement_circuits: Vec<Circuit> = Vec::new();
     // for random number generation
     let mut rng = thread_rng();
@@ -134,7 +134,7 @@ pub fn prepare_monte_carlo_gate_test(
         );
 
         let j = measurement_input
-            .add_pauli_product(format!("ro_{}", i), pauli_product_mask)
+            .add_pauliz_product(format!("ro_{}", i), pauli_product_mask)
             .unwrap();
         let mut linear_map: HashMap<usize, f64> = HashMap::new();
         linear_map.insert(j, 1.0);
@@ -154,7 +154,7 @@ pub fn prepare_monte_carlo_gate_test(
             * init_matrix)[(0, 0)];
         let _ = expected_values.insert(format!("exp_val_{}", i), expected_value.re);
     }
-    let measurement = BasisRotation {
+    let measurement = PauliZProduct {
         circuits: measurement_circuits,
         input: measurement_input,
         constant_circuit: None,

--- a/roqoqo/src/lib.rs
+++ b/roqoqo/src/lib.rs
@@ -210,7 +210,7 @@ pub enum RoqoqoError {
     },
     /// Error occured in basis rotation measurement.
     #[error("Error occured in basis rotation measurement. {msg}")]
-    BasisRotationMeasurementError {
+    PauliZProductMeasurementError {
         /// Error message.
         msg: String,
     },

--- a/roqoqo/src/measurements/basis_rotation_measurement.rs
+++ b/roqoqo/src/measurements/basis_rotation_measurement.rs
@@ -19,16 +19,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct BasisRotation {
+pub struct PauliZProduct {
     /// Constant Circuit that is executed before each Circuit in circuits.
     pub constant_circuit: Option<Circuit>,
     /// Collection of quantum circuits for the separate basis rotations.
     pub circuits: Vec<Circuit>,
     /// Additional input information required for measurement.
-    pub input: BasisRotationInput,
+    pub input: PauliZProductInput,
 }
 
-impl Measure for BasisRotation {
+impl Measure for PauliZProduct {
     /// Returns the constant Circuit that is executed before each Circuit in circuits.
     ///
     /// # Returns
@@ -86,7 +86,7 @@ impl Measure for BasisRotation {
     }
 }
 
-impl MeasureExpectationValues for BasisRotation {
+impl MeasureExpectationValues for PauliZProduct {
     // TODO add optional device later for use with flipped measurement
     #[allow(unused_variables)]
     /// Executes the basis rotation measurement.
@@ -101,7 +101,7 @@ impl MeasureExpectationValues for BasisRotation {
     ///
     /// * `Ok(Some(HashMap<String, f64>))` - The measurement has been evaluated successfully. The HashMap contains the measured expectation values.
     /// * `Ok(None)` - The measurement did not fail but is incomplete. A new round of measurements is needed
-    /// * `Err([RoqoqoError::BasisRotationMeasurementError])` - An error occured in basis rotation measurement.
+    /// * `Err([RoqoqoError::PauliZProductMeasurementError])` - An error occured in basis rotation measurement.
     ///
     fn evaluate(
         &self,
@@ -141,7 +141,7 @@ impl MeasureExpectationValues for BasisRotation {
             for (flip_measurement, extension) in flipped_and_extension.iter() {
                 let register = bit_registers
                     .get(&format!("{}{}", register_name.as_str(), extension))
-                    .ok_or(RoqoqoError::BasisRotationMeasurementError {
+                    .ok_or(RoqoqoError::PauliZProductMeasurementError {
                         msg: format!(
                             "bit register {}{} not found",
                             register_name.as_str(),
@@ -179,7 +179,7 @@ impl MeasureExpectationValues for BasisRotation {
                     Array1::zeros(self.input.number_pauli_products);
                 for i in 0..self.input.number_pauli_products {
                     pauli_products_tmp[i] = single_shot_pauli_products.column(i).mean().ok_or(
-                        RoqoqoError::BasisRotationMeasurementError {
+                        RoqoqoError::PauliZProductMeasurementError {
                             msg: format!(
                                 "Column {} out of index for sinlge_shot_pauli_products",
                                 i
@@ -202,13 +202,13 @@ impl MeasureExpectationValues for BasisRotation {
                 if self.input.use_flipped_measurement {
                     let tmp_pauli_products = (&pauli_product_dict
                         .get(register_name.as_str())
-                        .ok_or(RoqoqoError::BasisRotationMeasurementError {
+                        .ok_or(RoqoqoError::PauliZProductMeasurementError {
                             msg: format!("Register name {} not fount", register_name),
                         })?
                         .view()
                         + &pauli_product_dict
                             .get(format!("{}_flipped", register_name).as_str())
-                            .ok_or(RoqoqoError::BasisRotationMeasurementError {
+                            .ok_or(RoqoqoError::PauliZProductMeasurementError {
                                 msg: format!("Register name {}_flipped not fount", register_name),
                             })?
                             .view())
@@ -218,7 +218,7 @@ impl MeasureExpectationValues for BasisRotation {
                 } else {
                     pauli_products += &pauli_product_dict
                         .get(register_name.as_str())
-                        .ok_or(RoqoqoError::BasisRotationMeasurementError {
+                        .ok_or(RoqoqoError::PauliZProductMeasurementError {
                             msg: format!("Register name {} not fount", register_name),
                         })?
                         .view()

--- a/roqoqo/src/measurements/cheated_basis_rotation_measurement.rs
+++ b/roqoqo/src/measurements/cheated_basis_rotation_measurement.rs
@@ -19,16 +19,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct CheatedBasisRotation {
+pub struct CheatedPauliZProduct {
     /// Constant Circuit that is executed before each Circuit in circuits.
     pub constant_circuit: Option<Circuit>,
     /// Collection of quantum circuits for the separate basis rotations.
     pub circuits: Vec<Circuit>,
     /// Additional input information required for measurement.
-    pub input: CheatedBasisRotationInput,
+    pub input: CheatedPauliZProductInput,
 }
 
-impl Measure for CheatedBasisRotation {
+impl Measure for CheatedPauliZProduct {
     /// Returns the constant Circuit that is executed before each Circuit in circuits.
     ///
     /// # Returns
@@ -85,7 +85,7 @@ impl Measure for CheatedBasisRotation {
     }
 }
 
-impl MeasureExpectationValues for CheatedBasisRotation {
+impl MeasureExpectationValues for CheatedPauliZProduct {
     /// Executes the cheated basis rotation measurement
     ///
     /// # Arguments

--- a/roqoqo/src/measurements/measurement_auxiliary_data_input.rs
+++ b/roqoqo/src/measurements/measurement_auxiliary_data_input.rs
@@ -40,15 +40,15 @@ pub enum PauliProductsToExpVal {
     Symbolic(CalculatorFloat),
 }
 
-/// Provides Necessary Information to run a [crate::measurements::BasisRotation] measurement.
+/// Provides Necessary Information to run a [crate::measurements::PauliZProduct] measurement.
 ///
-/// BasisRotationInput is the input struct for a BasisRotation measurement, dictating which expectation
-/// values are measured by BasisRotation. These expecation values are defined as
+/// PauliZProductInput is the input struct for a PauliZProduct measurement, dictating which expectation
+/// values are measured by PauliZProduct. These expecation values are defined as
 /// expectation values of pauli products.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub struct BasisRotationInput {
+pub struct PauliZProductInput {
     /// Collection of PauliProductMasks for each readout register in Measurement.
     pub pauli_product_qubit_masks: HashMap<String, SingleReadoutPauliProductMasks>,
     /// Number of qubits that are measured.
@@ -65,17 +65,17 @@ pub struct BasisRotationInput {
     pub use_flipped_measurement: bool,
 }
 
-impl BasisRotationInput {
-    /// Creates new BasisRotationInput.
+impl PauliZProductInput {
+    /// Creates new PauliZProductInput.
     ///
-    /// The BasisRotationInput starts with just the number of qubtis and flipped measurements set.
+    /// The PauliZProductInput starts with just the number of qubtis and flipped measurements set.
     /// The pauli_product_qubit_masks and measured_exp_vals start empty
-    /// and can be extended with [BasisRotationInput::add_pauli_product],
-    /// [BasisRotationInput::add_linear_exp_val] and [BasisRotationInput::add_symbolic_exp_val].
+    /// and can be extended with [PauliZProductInput::add_pauliz_product],
+    /// [PauliZProductInput::add_linear_exp_val] and [PauliZProductInput::add_symbolic_exp_val].
     ///
     /// # Arguments
     ///
-    /// * `number_qubits` - The number of qubits in the BasisRotation measurement.
+    /// * `number_qubits` - The number of qubits in the PauliZProduct measurement.
     /// * `use_flipped_measurement` - Whether or not to use flipped measurements.
     ///
     pub fn new(number_qubits: usize, use_flipped_measurement: bool) -> Self {
@@ -88,7 +88,7 @@ impl BasisRotationInput {
         }
     }
 
-    /// Adds measured Pauli product to BasisRotationInput and returns index of Pauli product.
+    /// Adds measured Pauli product to PauliZProductInput and returns index of Pauli product.
     ///
     /// When the pauli product is already in the measurement input the function only returns
     /// it index.
@@ -102,7 +102,7 @@ impl BasisRotationInput {
     ///
     /// * `Ok(usize)` - The index of the added Pauli product in the list of all Pauli products.
     /// * `Err([RoqoqoError::PauliProductExceedsQubits])` - The pauli product involves a qubit exceeding the maximum number of qubits.
-    pub fn add_pauli_product(
+    pub fn add_pauliz_product(
         &mut self,
         readout: String,
         pauli_product_mask: PauliProductMask,
@@ -198,13 +198,13 @@ impl BasisRotationInput {
     }
 }
 
-/// Provides necessary information to run a [crate::measurements::CheatedBasisRotation] measurement.
+/// Provides necessary information to run a [crate::measurements::CheatedPauliZProduct] measurement.
 ///
-/// Is used by the full measurement struct [crate::measurements::CheatedBasisRotation].
+/// Is used by the full measurement struct [crate::measurements::CheatedPauliZProduct].
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
-pub struct CheatedBasisRotationInput {
+pub struct CheatedPauliZProductInput {
     /// Collection of names and construction methods of  expectation values.
     ///
     /// The construction methods are given by [PauliProductsToExpVal] enums.
@@ -213,19 +213,19 @@ pub struct CheatedBasisRotationInput {
     pub pauli_product_keys: HashMap<String, usize>,
 }
 
-impl Default for CheatedBasisRotationInput {
-    /// Creates a default (here, new) instance of CheatedBasisRotationInput.
+impl Default for CheatedPauliZProductInput {
+    /// Creates a default (here, new) instance of CheatedPauliZProductInput.
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl CheatedBasisRotationInput {
-    /// Creates new CheatedBasisRotationInput.
+impl CheatedPauliZProductInput {
+    /// Creates new CheatedPauliZProductInput.
     ///
     /// # Returns
     ///
-    /// * `Self` - The new instance of CheatedBasisRotationInput with measured_exp_vals = an empty
+    /// * `Self` - The new instance of CheatedPauliZProductInput with measured_exp_vals = an empty
     ///            HashMap and pauli_product_keys = an empty HashMap.
     pub fn new() -> Self {
         Self {
@@ -234,7 +234,7 @@ impl CheatedBasisRotationInput {
         }
     }
 
-    /// Adds measured Pauli product to CheatedBasisRotationInput and returns index of Pauli product.
+    /// Adds measured Pauli product to CheatedPauliZProductInput and returns index of Pauli product.
     ///
     /// When the pauli product is already in the measurement input the function only returns
     /// it index.
@@ -246,7 +246,7 @@ impl CheatedBasisRotationInput {
     /// # Returns
     ///
     /// * `usize` - The index of the added Pauli product in the list of all Pauli products.
-    pub fn add_pauli_product(&mut self, readout: String) -> usize {
+    pub fn add_pauliz_product(&mut self, readout: String) -> usize {
         if let Some((_, v)) = self.pauli_product_keys.iter().find(|(k, _)| k == &&readout) {
             return *v;
         }

--- a/roqoqo/src/measurements/mod.rs
+++ b/roqoqo/src/measurements/mod.rs
@@ -50,16 +50,16 @@ use crate::{
 /// # Example
 /// ```
 /// // We want to run a measurement for the following expectation value: 3 + 4.0 * < Z0 >.
-/// use roqoqo::{measurements::{BasisRotation, BasisRotationInput, Measure}, registers::BitOutputRegister, Circuit};
+/// use roqoqo::{measurements::{PauliZProduct, PauliZProductInput, Measure}, registers::BitOutputRegister, Circuit};
 /// use roqoqo::operations::RotateX;
 /// use std::collections::HashMap;
 ///
-/// // 1) Initialize our measurement input BasisRotationInput for the BasisRotation measurement
-/// let mut bri = BasisRotationInput::new(3, false);
+/// // 1) Initialize our measurement input PauliZProductInput for the PauliZProduct measurement
+/// let mut bri = PauliZProductInput::new(3, false);
 ///
 /// // 2) Add the pauli products to the input
-/// let _a = bri.add_pauli_product("ro".to_string(), vec![]);
-/// let _b = bri.add_pauli_product("ro".to_string(), vec![0]);
+/// let _a = bri.add_pauliz_product("ro".to_string(), vec![]);
+/// let _b = bri.add_pauliz_product("ro".to_string(), vec![0]);
 ///
 /// // 3) Add corresponding linear definition of expectation values
 /// let mut linear_map_0: HashMap<usize, f64> = HashMap::new();
@@ -69,15 +69,15 @@ use crate::{
 /// linear_map_1.insert(1, 4.0);
 /// bri.add_linear_exp_val("single_qubit_exp_val".to_string(), linear_map_1).unwrap();
 ///
-/// // 4) Construct circuits for the BasisRotation measurement
+/// // 4) Construct circuits for the PauliZProduct measurement
 /// let mut circs: Vec<Circuit> = Vec::new();
 /// circs.push(Circuit::new());
 /// let mut circ1 = Circuit::new();
 /// circ1 += RotateX::new(0, 0.0.into());
 /// circs.push(circ1);
 ///
-/// // 5) Initialize the BasisRotation with the circuits and input defined above
-/// let br = BasisRotation {
+/// // 5) Initialize the PauliZProduct with the circuits and input defined above
+/// let br = PauliZProduct {
 ///     constant_circuit: Some(Circuit::new()),
 ///     circuits: circs.clone(),
 ///     input: bri,
@@ -130,14 +130,14 @@ pub trait Measure: PartialEq + Clone {
 /// # Example
 /// ```
 /// // We want to run a measurement for the following expectation value: 3 + 4.0 * < Z0 >.
-/// use roqoqo::{measurements::{BasisRotation, BasisRotationInput, MeasureExpectationValues}, registers::BitOutputRegister, Circuit};
+/// use roqoqo::{measurements::{PauliZProduct, PauliZProductInput, MeasureExpectationValues}, registers::BitOutputRegister, Circuit};
 /// use std::collections::HashMap;
 ///
-/// // 1) Create and fill BasisRotationInput for the BasisRotation measurement
-/// let mut bri = BasisRotationInput::new(3, false);
+/// // 1) Create and fill PauliZProductInput for the PauliZProduct measurement
+/// let mut bri = PauliZProductInput::new(3, false);
 ///
-/// let _a = bri.add_pauli_product("ro".to_string(), vec![]);
-/// let _b = bri.add_pauli_product("ro".to_string(), vec![0]);
+/// let _a = bri.add_pauliz_product("ro".to_string(), vec![]);
+/// let _b = bri.add_pauliz_product("ro".to_string(), vec![0]);
 ///
 /// let mut linear_map_0: HashMap<usize, f64> = HashMap::new();
 /// linear_map_0.insert(0, 3.0);
@@ -146,11 +146,11 @@ pub trait Measure: PartialEq + Clone {
 /// linear_map_1.insert(1, 4.0);
 /// bri.add_linear_exp_val("single_qubit_exp_val".to_string(), linear_map_1).unwrap();
 ///
-/// // 2) Create and fill BasisRotation measurement
+/// // 2) Create and fill PauliZProduct measurement
 /// let mut circs: Vec<Circuit> = Vec::new();
 /// circs.push(Circuit::new());
 ///
-/// let br = BasisRotation {
+/// let br = PauliZProduct {
 ///     constant_circuit: None,
 ///     circuits: circs.clone(),
 ///     input: bri,
@@ -167,7 +167,7 @@ pub trait Measure: PartialEq + Clone {
 /// let new_output_register: BitOutputRegister = register;
 /// let _ = measured_registers.insert("ro".to_string(), new_output_register);
 ///
-/// // 4) Evaluate BasisRotation measurement
+/// // 4) Evaluate PauliZProduct measurement
 /// let result = br
 ///     .evaluate(measured_registers, HashMap::new(), HashMap::new())
 ///     .unwrap()

--- a/roqoqo/src/quantum_program.rs
+++ b/roqoqo/src/quantum_program.rs
@@ -35,16 +35,16 @@ use std::fmt::{Display, Formatter};
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum QuantumProgram {
     /// Variant for basis rotation measurement based quantum programs
-    BasisRotation {
+    PauliZProduct {
         /// The measurement that is performed
-        measurement: measurements::BasisRotation,
+        measurement: measurements::PauliZProduct,
         /// List of free input parameters that can be set when the QuantumProgram is executed
         input_parameter_names: Vec<String>,
     },
     /// Variant for cheated basis rotation measurement based quantum programs
-    CheatedBasisRotation {
+    CheatedPauliZProduct {
         /// The measurement that is performed
-        measurement: measurements::CheatedBasisRotation,
+        measurement: measurements::CheatedPauliZProduct,
         /// List of free input parameters that can be set when the QuantumProgram is executed
         input_parameter_names: Vec<String>,
     },
@@ -83,7 +83,7 @@ impl QuantumProgram {
         T: EvaluatingBackend,
     {
         match self{
-            QuantumProgram::BasisRotation{measurement, input_parameter_names } => {
+            QuantumProgram::PauliZProduct{measurement, input_parameter_names } => {
                 if parameters.len() != input_parameter_names.len() { return Err(RoqoqoBackendError::GenericError{msg: format!("Wrong number of parameters {} parameters expected {} parameters given", input_parameter_names.len(), parameters.len())})};
                 let substituted_parameters: HashMap<String, f64> = input_parameter_names.iter().zip(parameters.iter()).map(|(key, value)| (key.clone(), *value)).collect();
                 let substituted_measurement = measurement.substitute_parameters(
@@ -91,7 +91,7 @@ impl QuantumProgram {
                 )?;
                 backend.run_measurement(&substituted_measurement)
             }
-            QuantumProgram::CheatedBasisRotation{measurement, input_parameter_names } => {
+            QuantumProgram::CheatedPauliZProduct{measurement, input_parameter_names } => {
                 if parameters.len() != input_parameter_names.len() { return Err(RoqoqoBackendError::GenericError{msg: format!("Wrong number of parameters {} parameters expected {} parameters given", input_parameter_names.len(), parameters.len())})};
                 let substituted_parameters: HashMap<String, f64> = input_parameter_names.iter().zip(parameters.iter()).map(|(key, value)| (key.clone(), *value)).collect();
                 let substituted_measurement = measurement.substitute_parameters(
@@ -147,11 +147,11 @@ impl Display for QuantumProgram {
         let mut s: String = String::new();
 
         match self {
-            QuantumProgram::BasisRotation { .. } => {
-                s.push_str("QuantumProgram::BasisRotation");
+            QuantumProgram::PauliZProduct { .. } => {
+                s.push_str("QuantumProgram::PauliZProduct");
             }
-            QuantumProgram::CheatedBasisRotation { .. } => {
-                s.push_str("QuantumProgram::CheatedBasisRotation");
+            QuantumProgram::CheatedPauliZProduct { .. } => {
+                s.push_str("QuantumProgram::CheatedPauliZProduct");
             }
             QuantumProgram::Cheated { .. } => {
                 s.push_str("QuantumProgram::Cheated");

--- a/roqoqo/tests/integration/measurements/basis_rotation_measurement.rs
+++ b/roqoqo/tests/integration/measurements/basis_rotation_measurement.rs
@@ -19,22 +19,22 @@ use roqoqo::operations;
 use roqoqo::prelude::*;
 use roqoqo::Circuit;
 use roqoqo::{
-    measurements::{BasisRotation, BasisRotationInput},
+    measurements::{PauliZProduct, PauliZProductInput},
     registers::BitOutputRegister,
 };
 use test_case::test_case;
 
 #[test]
 fn test_returning_circuits() {
-    let mut bri = BasisRotationInput::new(3, false);
-    let _ = bri.add_pauli_product("ro".to_string(), vec![]);
-    let _ = bri.add_pauli_product("ro".to_string(), vec![0]);
-    let _ = bri.add_pauli_product("ro".to_string(), vec![0, 1]);
+    let mut bri = PauliZProductInput::new(3, false);
+    let _ = bri.add_pauliz_product("ro".to_string(), vec![]);
+    let _ = bri.add_pauliz_product("ro".to_string(), vec![0]);
+    let _ = bri.add_pauliz_product("ro".to_string(), vec![0, 1]);
     let mut circs: Vec<Circuit> = vec![Circuit::new()];
     let mut circ1 = Circuit::new();
     circ1 += operations::RotateX::new(0, 0.0.into());
     circs.push(circ1);
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: Some(Circuit::new()),
         circuits: circs.clone(),
         input: bri,
@@ -47,12 +47,12 @@ fn test_returning_circuits() {
 
 #[test]
 fn test_clone_eq_format() {
-    let bri = BasisRotationInput::new(3, false);
+    let bri = PauliZProductInput::new(3, false);
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     circ1 += operations::RotateX::new(0, 0.0.into());
     circs.push(circ1);
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: Some(Circuit::new()),
         circuits: circs.clone(),
         input: bri.clone(),
@@ -66,7 +66,7 @@ fn test_clone_eq_format() {
     let mut circ1 = Circuit::new();
     circ1 += operations::RotateX::new(1, "theta".into());
     circs.push(circ1);
-    let br2 = BasisRotation {
+    let br2 = PauliZProduct {
         constant_circuit: Some(Circuit::new()),
         circuits: circs.clone(),
         input: bri,
@@ -80,7 +80,7 @@ fn test_clone_eq_format() {
 
 #[test]
 fn test_substitute_parameters() {
-    let bri = BasisRotationInput::new(3, false);
+    let bri = PauliZProductInput::new(3, false);
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     let mut circ1_subs = Circuit::new();
@@ -91,7 +91,7 @@ fn test_substitute_parameters() {
     circ2 += operations::RotateZ::new(0, "theta2".into());
     circ2_subs += operations::RotateZ::new(0, 1.0.into());
     circs.push(circ1);
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: Some(circ2),
         circuits: circs.clone(),
         input: bri,
@@ -111,7 +111,7 @@ fn test_substitute_parameters() {
 
 #[test]
 fn test_substitute_parameters_fail() {
-    let bri = BasisRotationInput::new(3, false);
+    let bri = PauliZProductInput::new(3, false);
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     let mut circ1_subs = Circuit::new();
@@ -122,7 +122,7 @@ fn test_substitute_parameters_fail() {
     circ2 += operations::RotateZ::new(0, "theta2".into());
     circ2_subs += operations::RotateZ::new(0, 1.0.into());
     circs.push(circ1);
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: Some(circ2),
         circuits: circs.clone(),
         input: bri,
@@ -163,11 +163,11 @@ fn test_evaluate_linear(
     two_qubit_exp_val: f64,
     two_pp_exp_val: f64,
 ) {
-    let mut bri = BasisRotationInput::new(3, false);
-    let _a = bri.add_pauli_product("ro".to_string(), vec![]);
-    let _b = bri.add_pauli_product("ro".to_string(), vec![0]);
-    let _c = bri.add_pauli_product("ro".to_string(), vec![1, 2]);
-    let _d = bri.add_pauli_product("rx".to_string(), vec![1, 2]);
+    let mut bri = PauliZProductInput::new(3, false);
+    let _a = bri.add_pauliz_product("ro".to_string(), vec![]);
+    let _b = bri.add_pauliz_product("ro".to_string(), vec![0]);
+    let _c = bri.add_pauliz_product("ro".to_string(), vec![1, 2]);
+    let _d = bri.add_pauliz_product("rx".to_string(), vec![1, 2]);
     let mut linear_map: HashMap<usize, f64> = HashMap::new();
     linear_map.insert(0, 3.0);
     bri.add_linear_exp_val("constant".to_string(), linear_map)
@@ -190,7 +190,7 @@ fn test_evaluate_linear(
         .unwrap();
 
     let circs: Vec<Circuit> = vec![Circuit::new()];
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: None,
         circuits: circs,
         input: bri,
@@ -257,10 +257,10 @@ fn test_evaluate_linear_flipped(
     two_qubit_exp_val: f64,
     two_pp_exp_val: f64,
 ) {
-    let mut bri = BasisRotationInput::new(3, true);
-    let _a = bri.add_pauli_product("ro".to_string(), vec![]);
-    let _b = bri.add_pauli_product("ro".to_string(), vec![0]);
-    let _c = bri.add_pauli_product("ro".to_string(), vec![1, 2]);
+    let mut bri = PauliZProductInput::new(3, true);
+    let _a = bri.add_pauliz_product("ro".to_string(), vec![]);
+    let _b = bri.add_pauliz_product("ro".to_string(), vec![0]);
+    let _c = bri.add_pauliz_product("ro".to_string(), vec![1, 2]);
     let mut linear_map: HashMap<usize, f64> = HashMap::new();
     linear_map.insert(0, 3.0);
     bri.add_linear_exp_val("constant".to_string(), linear_map)
@@ -283,7 +283,7 @@ fn test_evaluate_linear_flipped(
         .unwrap();
 
     let circs: Vec<Circuit> = vec![Circuit::new()];
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: None,
         circuits: circs,
         input: bri,
@@ -322,18 +322,18 @@ fn test_evaluate_linear_flipped(
     vec![true, true, true],
 ], 3.0_f64.sin() + 1.0_f64.sin() ; "All measurements one")]
 fn test_evaluate_symbolic(register: Vec<Vec<bool>>, constant: f64) {
-    let mut bri = BasisRotationInput::new(3, false);
-    let _a = bri.add_pauli_product("ro".to_string(), vec![]);
-    let _b = bri.add_pauli_product("ro".to_string(), vec![0]);
-    let _c = bri.add_pauli_product("ro".to_string(), vec![1, 2]);
-    let _d = bri.add_pauli_product("rx".to_string(), vec![1, 2]);
+    let mut bri = PauliZProductInput::new(3, false);
+    let _a = bri.add_pauliz_product("ro".to_string(), vec![]);
+    let _b = bri.add_pauliz_product("ro".to_string(), vec![0]);
+    let _c = bri.add_pauliz_product("ro".to_string(), vec![1, 2]);
+    let _d = bri.add_pauliz_product("rx".to_string(), vec![1, 2]);
     let symbolic: CalculatorFloat =
         "sin(3.0 * pauli_product_0) + sin(-1.0 * pauli_product_1)".into();
     bri.add_symbolic_exp_val("constant".to_string(), symbolic)
         .unwrap();
 
     let circs: Vec<Circuit> = vec![Circuit::new()];
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: None,
         circuits: circs,
         input: bri,

--- a/roqoqo/tests/integration/measurements/cheated_basis_rotation_measurement.rs
+++ b/roqoqo/tests/integration/measurements/cheated_basis_rotation_measurement.rs
@@ -19,18 +19,18 @@ use roqoqo::operations;
 use roqoqo::prelude::*;
 use roqoqo::Circuit;
 use roqoqo::{
-    measurements::{CheatedBasisRotation, CheatedBasisRotationInput},
+    measurements::{CheatedPauliZProduct, CheatedPauliZProductInput},
     registers::FloatOutputRegister,
 };
 
 #[test]
 fn test_returning_circuits() {
-    let bri = CheatedBasisRotationInput::new();
+    let bri = CheatedPauliZProductInput::new();
     let mut circs: Vec<Circuit> = vec![Circuit::new()];
     let mut circ1 = Circuit::new();
     circ1 += operations::RotateX::new(0, 0.0.into());
     circs.push(circ1);
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: Some(Circuit::new()),
         circuits: circs.clone(),
         input: bri,
@@ -43,12 +43,12 @@ fn test_returning_circuits() {
 
 #[test]
 fn test_clone_eq_format() {
-    let bri = CheatedBasisRotationInput::new();
+    let bri = CheatedPauliZProductInput::new();
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     circ1 += operations::RotateX::new(0, 0.0.into());
     circs.push(circ1);
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: Some(Circuit::new()),
         circuits: circs.clone(),
         input: bri.clone(),
@@ -62,7 +62,7 @@ fn test_clone_eq_format() {
     let mut circ1 = Circuit::new();
     circ1 += operations::RotateX::new(1, "theta".into());
     circs.push(circ1);
-    let br2 = CheatedBasisRotation {
+    let br2 = CheatedPauliZProduct {
         constant_circuit: Some(Circuit::new()),
         circuits: circs.clone(),
         input: bri,
@@ -76,7 +76,7 @@ fn test_clone_eq_format() {
 
 #[test]
 fn test_substitute_parameters() {
-    let bri = CheatedBasisRotationInput::new();
+    let bri = CheatedPauliZProductInput::new();
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     let mut circ1_subs = Circuit::new();
@@ -87,7 +87,7 @@ fn test_substitute_parameters() {
     circ2 += operations::RotateZ::new(0, "theta2".into());
     circ2_subs += operations::RotateZ::new(0, 1.0.into());
     circs.push(circ1);
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: Some(circ2),
         circuits: circs.clone(),
         input: bri,
@@ -107,7 +107,7 @@ fn test_substitute_parameters() {
 
 #[test]
 fn test_substitute_parameters_fail() {
-    let bri = CheatedBasisRotationInput::new();
+    let bri = CheatedPauliZProductInput::new();
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     let mut circ1_subs = Circuit::new();
@@ -118,7 +118,7 @@ fn test_substitute_parameters_fail() {
     circ2 += operations::RotateZ::new(0, "theta2".into());
     circ2_subs += operations::RotateZ::new(0, 1.0.into());
     circs.push(circ1);
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: Some(circ2),
         circuits: circs.clone(),
         input: bri,
@@ -132,10 +132,10 @@ fn test_substitute_parameters_fail() {
 
 #[test]
 fn test_evaluate_linear() {
-    let mut bri = CheatedBasisRotationInput::new();
-    let _ = bri.add_pauli_product("ro_pauli_product_0".to_string());
-    let _ = bri.add_pauli_product("ro_pauli_product_1".to_string());
-    let _ = bri.add_pauli_product("ro_pauli_product_2".to_string());
+    let mut bri = CheatedPauliZProductInput::new();
+    let _ = bri.add_pauliz_product("ro_pauli_product_0".to_string());
+    let _ = bri.add_pauliz_product("ro_pauli_product_1".to_string());
+    let _ = bri.add_pauliz_product("ro_pauli_product_2".to_string());
 
     let mut linear_map: HashMap<usize, f64> = HashMap::new();
     linear_map.insert(0, 3.0);
@@ -150,7 +150,7 @@ fn test_evaluate_linear() {
         .unwrap();
 
     let circs: Vec<Circuit> = vec![Circuit::new()];
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: None,
         circuits: circs,
         input: bri,
@@ -170,17 +170,17 @@ fn test_evaluate_linear() {
 
 #[test]
 fn test_evaluate_symbolic() {
-    let mut bri = CheatedBasisRotationInput::new();
-    let _ = bri.add_pauli_product("ro_pauli_product_0".to_string());
-    let _ = bri.add_pauli_product("ro_pauli_product_1".to_string());
-    let _ = bri.add_pauli_product("ro_pauli_product_2".to_string());
+    let mut bri = CheatedPauliZProductInput::new();
+    let _ = bri.add_pauliz_product("ro_pauli_product_0".to_string());
+    let _ = bri.add_pauliz_product("ro_pauli_product_1".to_string());
+    let _ = bri.add_pauliz_product("ro_pauli_product_2".to_string());
     let symbolic: CalculatorFloat =
         "sin(3.0 * pauli_product_0) + sin(-1.0 * pauli_product_1)".into();
     bri.add_symbolic_exp_val("single_pp_val".to_string(), symbolic)
         .unwrap();
 
     let circs: Vec<Circuit> = vec![Circuit::new()];
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: None,
         circuits: circs,
         input: bri,

--- a/roqoqo/tests/integration/measurements/measurement_auxiliary_data_input.rs
+++ b/roqoqo/tests/integration/measurements/measurement_auxiliary_data_input.rs
@@ -14,7 +14,7 @@
 
 use num_complex::Complex64;
 use roqoqo::measurements::{
-    BasisRotationInput, CheatedBasisRotationInput, CheatedInput, PauliProductsToExpVal,
+    PauliZProductInput, CheatedPauliZProductInput, CheatedInput, PauliProductsToExpVal,
 };
 use roqoqo::RoqoqoError;
 use std::collections::HashMap;
@@ -36,22 +36,22 @@ fn test_pp_to_exp_val() {
 }
 #[test]
 fn test_clone_br() {
-    let bri = BasisRotationInput::new(3, false);
+    let bri = PauliZProductInput::new(3, false);
     let bri1 = bri.clone();
     assert_eq!(bri1, bri);
-    let bri2 = BasisRotationInput::new(4, true);
+    let bri2 = PauliZProductInput::new(4, true);
     let helper = bri != bri2;
     assert!(helper)
 }
 
 #[test]
 fn test_clone_cbr() {
-    let mut bri = CheatedBasisRotationInput::new();
-    let a = bri.add_pauli_product("test".to_string());
+    let mut bri = CheatedPauliZProductInput::new();
+    let a = bri.add_pauliz_product("test".to_string());
     assert_eq!(a, 0);
     let bri1 = bri.clone();
     assert_eq!(bri1, bri);
-    let bri2 = CheatedBasisRotationInput::new();
+    let bri2 = CheatedPauliZProductInput::new();
     let helper = bri != bri2;
     assert!(helper)
 }
@@ -71,7 +71,7 @@ fn test_clone_cheated() {
 
 #[test]
 fn test_format_br() {
-    let bri = BasisRotationInput::new(3, false);
+    let bri = PauliZProductInput::new(3, false);
     let string = format!("{:?}", bri);
     assert!(string.contains('3'));
     assert!(string.contains("false"));
@@ -79,8 +79,8 @@ fn test_format_br() {
 
 #[test]
 fn test_format_cbr() {
-    let mut bri = CheatedBasisRotationInput::new();
-    let _ = bri.add_pauli_product("test".to_string());
+    let mut bri = CheatedPauliZProductInput::new();
+    let _ = bri.add_pauliz_product("test".to_string());
     let string = format!("{:?}", bri);
     assert!(string.contains("test"));
     assert!(string.contains('0'));
@@ -99,33 +99,33 @@ fn test_format_cheated() {
 
 #[test]
 fn double_insertion_br() {
-    let mut bri = BasisRotationInput::new(3, false);
-    let x = bri.add_pauli_product("ro".to_string(), vec![0]).unwrap();
+    let mut bri = PauliZProductInput::new(3, false);
+    let x = bri.add_pauliz_product("ro".to_string(), vec![0]).unwrap();
     assert_eq!(x, 0);
-    let x = bri.add_pauli_product("ro".to_string(), vec![1]).unwrap();
+    let x = bri.add_pauliz_product("ro".to_string(), vec![1]).unwrap();
     assert_eq!(x, 1);
-    let x = bri.add_pauli_product("ro".to_string(), vec![1]).unwrap();
+    let x = bri.add_pauliz_product("ro".to_string(), vec![1]).unwrap();
     assert_eq!(x, 1);
-    let x = bri.add_pauli_product("rx".to_string(), vec![1]).unwrap();
+    let x = bri.add_pauliz_product("rx".to_string(), vec![1]).unwrap();
     assert_eq!(x, 2);
 }
 
 #[test]
 fn double_insertion_cbr() {
-    let mut bri = CheatedBasisRotationInput::new();
-    let a = bri.add_pauli_product("test".to_string());
+    let mut bri = CheatedPauliZProductInput::new();
+    let a = bri.add_pauliz_product("test".to_string());
     assert_eq!(a, 0);
-    let a = bri.add_pauli_product("test2".to_string());
+    let a = bri.add_pauliz_product("test2".to_string());
     assert_eq!(a, 1);
-    let a = bri.add_pauli_product("test".to_string());
+    let a = bri.add_pauliz_product("test".to_string());
     assert_eq!(a, 0);
-    let a = bri.add_pauli_product("tset".to_string());
+    let a = bri.add_pauliz_product("tset".to_string());
     assert_eq!(a, 2);
 }
 
 #[test]
 fn error_br() {
-    let mut bri = BasisRotationInput::new(3, false);
+    let mut bri = PauliZProductInput::new(3, false);
     let _ = bri.add_symbolic_exp_val("test".to_string(), "3.0".into());
     let a = bri.add_symbolic_exp_val("test".to_string(), "3.0".into());
     assert_eq!(
@@ -141,7 +141,7 @@ fn error_br() {
             name: "test".to_string()
         })
     );
-    let a = bri.add_pauli_product("tset".to_string(), vec![3]);
+    let a = bri.add_pauliz_product("tset".to_string(), vec![3]);
     assert_eq!(
         a,
         Err(RoqoqoError::PauliProductExceedsQubits {
@@ -153,7 +153,7 @@ fn error_br() {
 
 #[test]
 fn error_cbr() {
-    let mut bri = CheatedBasisRotationInput::new();
+    let mut bri = CheatedPauliZProductInput::new();
     let _ = bri.add_symbolic_exp_val("test".to_string(), "3.0".into());
     let a = bri.add_symbolic_exp_val("test".to_string(), "3.0".into());
     assert_eq!(
@@ -197,6 +197,6 @@ fn error_cheated() {
 
 #[test]
 fn default_cbr() {
-    let bri: CheatedBasisRotationInput = Default::default();
-    assert_eq!(bri, CheatedBasisRotationInput::new());
+    let bri: CheatedPauliZProductInput = Default::default();
+    assert_eq!(bri, CheatedPauliZProductInput::new());
 }

--- a/roqoqo/tests/integration/measurements/measurement_auxiliary_data_input.rs
+++ b/roqoqo/tests/integration/measurements/measurement_auxiliary_data_input.rs
@@ -14,7 +14,7 @@
 
 use num_complex::Complex64;
 use roqoqo::measurements::{
-    PauliZProductInput, CheatedPauliZProductInput, CheatedInput, PauliProductsToExpVal,
+    CheatedInput, CheatedPauliZProductInput, PauliProductsToExpVal, PauliZProductInput,
 };
 use roqoqo::RoqoqoError;
 use std::collections::HashMap;

--- a/roqoqo/tests/integration/quantum_program.rs
+++ b/roqoqo/tests/integration/quantum_program.rs
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 use roqoqo::measurements::{
-    BasisRotation, BasisRotationInput, Cheated, CheatedBasisRotation, CheatedBasisRotationInput,
+    PauliZProduct, PauliZProductInput, Cheated, CheatedPauliZProduct, CheatedPauliZProductInput,
     CheatedInput, ClassicalRegister,
 };
 use roqoqo::operations;
@@ -47,7 +47,7 @@ impl EvaluatingBackend for TestBackend {
 #[test]
 fn test_basis_rotation() {
     // setting ub BR measurement
-    let bri = BasisRotationInput::new(3, false);
+    let bri = PauliZProductInput::new(3, false);
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     let mut circ1_subs = Circuit::new();
@@ -58,14 +58,14 @@ fn test_basis_rotation() {
     circ2 += operations::RotateZ::new(0, "theta2".into());
     circ2_subs += operations::RotateZ::new(0, 1.0.into());
     circs.push(circ1);
-    let br = BasisRotation {
+    let br = PauliZProduct {
         constant_circuit: Some(circ2),
         circuits: circs.clone(),
         input: bri,
     };
 
     let input_parameter_names = vec!["theta".to_string(), "theta2".to_string()];
-    let program = QuantumProgram::BasisRotation {
+    let program = QuantumProgram::PauliZProduct {
         measurement: br,
         input_parameter_names,
     };
@@ -85,7 +85,7 @@ fn test_basis_rotation() {
 #[test]
 fn test_cheated_basis_rotation() {
     // setting ub BR measurement
-    let bri = CheatedBasisRotationInput::new();
+    let bri = CheatedPauliZProductInput::new();
     let mut circs: Vec<Circuit> = Vec::new();
     let mut circ1 = Circuit::new();
     let mut circ1_subs = Circuit::new();
@@ -96,14 +96,14 @@ fn test_cheated_basis_rotation() {
     circ2 += operations::RotateZ::new(0, "theta2".into());
     circ2_subs += operations::RotateZ::new(0, 1.0.into());
     circs.push(circ1);
-    let br = CheatedBasisRotation {
+    let br = CheatedPauliZProduct {
         constant_circuit: Some(circ2),
         circuits: circs.clone(),
         input: bri,
     };
 
     let input_parameter_names = vec!["theta".to_string(), "theta2".to_string()];
-    let program = QuantumProgram::CheatedBasisRotation {
+    let program = QuantumProgram::CheatedPauliZProduct {
         measurement: br,
         input_parameter_names,
     };

--- a/roqoqo/tests/integration/quantum_program.rs
+++ b/roqoqo/tests/integration/quantum_program.rs
@@ -11,8 +11,8 @@
 // limitations under the License.
 
 use roqoqo::measurements::{
-    PauliZProduct, PauliZProductInput, Cheated, CheatedPauliZProduct, CheatedPauliZProductInput,
-    CheatedInput, ClassicalRegister,
+    Cheated, CheatedInput, CheatedPauliZProduct, CheatedPauliZProductInput, ClassicalRegister,
+    PauliZProduct, PauliZProductInput,
 };
 use roqoqo::operations;
 use roqoqo::prelude::*;


### PR DESCRIPTION
BasisRotation and CheatedBasisRotation measurements renamed in roqoqo/qoqo to PauliZProduct or CheatedPauliZProduct respectively.