### PR TITLE
Device support for 3-qubit operations

### DIFF
--- a/qoqo-macros/src/lib.rs
+++ b/qoqo-macros/src/lib.rs
@@ -630,25 +630,25 @@ pub fn devicewrapper(
                     .two_qubit_gate_time(hqslang, &control, &target)
             }
 
-            // /// Returns the gate time of a three qubit operation if the three qubit operation is available on device.
-            // ///
-            // /// Args:
-            // ///     hqslang[str]: The hqslang name of a single qubit gate.
-            // ///     control_0[int]: The control_0 qubit the gate acts on.
-            // ///     control_1[int]: The control_1 qubit the gate acts on.
-            // ///     target[int]: The target qubit the gate acts on.
-            // ///
-            // /// Returns:
-            // ///     Option[float]: None if gate is not available
-            // ///
-            // /// Raises:
-            // ///     PyValueError: Qubit is not in device
-            // ///
-            // #[pyo3(text_signature = "(gate, control_0, control_1, target")]
-            // pub fn three_qubit_gate_time(&self, hqslang: &str, control_0: usize, control_1: usize, target: usize) -> Option<f64> {
-            //     self.internal
-            //         .three_qubit_gate_time(hqslang, &control_0, &control_1, &target)
-            // }
+            /// Returns the gate time of a three qubit operation if the three qubit operation is available on device.
+            ///
+            /// Args:
+            ///     hqslang[str]: The hqslang name of a single qubit gate.
+            ///     control_0[int]: The control_0 qubit the gate acts on.
+            ///     control_1[int]: The control_1 qubit the gate acts on.
+            ///     target[int]: The target qubit the gate acts on.
+            ///
+            /// Returns:
+            ///     Option[float]: None if gate is not available
+            ///
+            /// Raises:
+            ///     PyValueError: Qubit is not in device
+            ///
+            #[pyo3(text_signature = "(gate, control_0, control_1, target")]
+            pub fn three_qubit_gate_time(&self, hqslang: &str, control_0: usize, control_1: usize, target: usize) -> Option<f64> {
+                self.internal
+                    .three_qubit_gate_time(hqslang, &control_0, &control_1, &target)
+            }
 
             /// Returns the gate time of a multi qubit operation if the multi qubit operation is available on device.
             ///
@@ -697,22 +697,22 @@ pub fn devicewrapper(
                     PyValueError::new_err(format!("{:?}", err)))
             }
 
-            // /// Set the gate time of a three qubit gate.
-            // ///
-            // /// Args:
-            // ///     gate (str): hqslang name of the single-qubit-gate.
-            // ///     control_0 (int): The control_0 qubit for which the gate time is set
-            // ///     control_1 (int): The control_1 qubit for which the gate time is set
-            // ///     target (int): The control qubit for which the gate time is set
-            // ///     gate_time (float): The gate time for the given gate.
-            // ///
-            // /// Raises:
-            // ///     PyValueError: Qubit is not in device
-            // #[pyo3(text_signature = "(qubit, control_0, control_1, target, gate_time)")]
-            // pub fn set_three_qubit_gate_time(&mut self, gate: &str, control_0: usize, control_1: usize, target: usize, gate_time: f64) -> PyResult<()> {
-            //     self.internal.set_three_qubit_gate_time(gate, control_0, control_1, target, gate_time).map_err(|err|
-            //         PyValueError::new_err(format!("{:?}", err)))
-            // }
+            /// Set the gate time of a three qubit gate.
+            ///
+            /// Args:
+            ///     gate (str): hqslang name of the single-qubit-gate.
+            ///     control_0 (int): The control_0 qubit for which the gate time is set
+            ///     control_1 (int): The control_1 qubit for which the gate time is set
+            ///     target (int): The control qubit for which the gate time is set
+            ///     gate_time (float): The gate time for the given gate.
+            ///
+            /// Raises:
+            ///     PyValueError: Qubit is not in device
+            #[pyo3(text_signature = "(qubit, control_0, control_1, target, gate_time)")]
+            pub fn set_three_qubit_gate_time(&mut self, gate: &str, control_0: usize, control_1: usize, target: usize, gate_time: f64) -> PyResult<()> {
+                self.internal.set_three_qubit_gate_time(gate, control_0, control_1, target, gate_time).map_err(|err|
+                    PyValueError::new_err(format!("{:?}", err)))
+            }
 
 
             /// Set the gate time of a single qubit gate.

--- a/qoqo/src/devices/all_to_all.rs
+++ b/qoqo/src/devices/all_to_all.rs
@@ -149,7 +149,6 @@ impl AllToAllDeviceWrapper {
     /// Returns:
     ///     AllToAllDevice
     #[pyo3(text_signature = "(dephasing)")]
-
     pub fn add_dephasing_all(&mut self, dephasing: f64) -> Self {
         Self {
             internal: self.internal.clone().add_dephasing_all(dephasing),

--- a/qoqo/tests/integration/devices.rs
+++ b/qoqo/tests/integration/devices.rs
@@ -23,12 +23,10 @@ fn new_alltoalldevice() -> Py<PyAny> {
         let number_qubits = 4;
         let single_qubit_gates = ["RotateX".to_string(), "RotateZ".to_string()];
         let two_qubit_gates = ["CNOT".to_string()];
-        // let three_qubit_gates = ["ControlledControlledPauliZ".to_string()];
         let arguments: (usize, [String; 2], [String; 1], f64) = (
             number_qubits,
             single_qubit_gates,
             two_qubit_gates,
-            // three_qubit_gates,
             1.0,
         );
         let device_type = py.get_type::<AllToAllDeviceWrapper>();
@@ -54,13 +52,11 @@ fn new_genericlattice() -> Py<PyAny> {
         let number_columns: usize = 2;
         let single_qubit_gates = ["RotateX".to_string(), "RotateZ".to_string()];
         let two_qubit_gates = ["CNOT".to_string()];
-        // let three_qubit_gates = ["ControlledControlledPauliZ".to_string()];
         let arguments: (usize, usize, [String; 2], [String; 1], f64) = (
             number_rows,
             number_columns,
             single_qubit_gates,
             two_qubit_gates,
-            // three_qubit_gates,
             1.0,
         );
         let device_type = py.get_type::<SquareLatticeDeviceWrapper>();
@@ -372,39 +368,39 @@ fn test_gatetimes(device: Py<PyAny>) {
         assert_eq!(gate_time_cnot, Some(gate_time));
         assert_eq!(gate_time_none2, None);
 
-        // // Test three qubit gate times
-        // device
-        //     .call_method1(
-        //         py,
-        //         "set_three_qubit_gate_time",
-        //         ("ControlledControlledPauliZ", 0, 1, 2, gate_time),
-        //     )
-        //     .unwrap();
+        // Test three qubit gate times
+        device
+            .call_method1(
+                py,
+                "set_three_qubit_gate_time",
+                ("ControlledControlledPauliZ", 0, 1, 2, gate_time),
+            )
+            .unwrap();
 
-        // // get the gate time for CCZs on qubit 0 1 2
-        // let gate_time_ccz = device
-        //     .call_method1(
-        //         py,
-        //         "three_qubit_gate_time",
-        //         ("ControlledControlledPauliZ", 0_i64, 1_i64, 2_i64),
-        //     )
-        //     .unwrap()
-        //     .extract::<Option<f64>>(py)
-        //     .unwrap();
+        // get the gate time for CCZs on qubit 0 1 2
+        let gate_time_ccz = device
+            .call_method1(
+                py,
+                "three_qubit_gate_time",
+                ("ControlledControlledPauliZ", 0_i64, 1_i64, 2_i64),
+            )
+            .unwrap()
+            .extract::<Option<f64>>(py)
+            .unwrap();
 
-        // // get the gate time for CCZ for a qubit not which is not in the device
-        // let gate_time_none3 = device
-        //     .call_method1(
-        //         py,
-        //         "three_qubit_gate_time",
-        //         ("ControlledControlledPauliZ", 0_i64, 4_i64, 100_i64),
-        //     )
-        //     .unwrap()
-        //     .extract::<Option<f64>>(py)
-        //     .unwrap();
+        // get the gate time for CCZ for a qubit not which is not in the device
+        let gate_time_none3 = device
+            .call_method1(
+                py,
+                "three_qubit_gate_time",
+                ("ControlledControlledPauliZ", 0_i64, 4_i64, 100_i64),
+            )
+            .unwrap()
+            .extract::<Option<f64>>(py)
+            .unwrap();
 
-        // assert_eq!(gate_time_ccz, Some(gate_time));
-        // assert_eq!(gate_time_none3, None);
+        assert_eq!(gate_time_ccz, Some(gate_time));
+        assert_eq!(gate_time_none3, None);
 
         // Test multi qubit gate times
         device

--- a/roqoqo/src/devices/all_to_all.rs
+++ b/roqoqo/src/devices/all_to_all.rs
@@ -174,33 +174,33 @@ impl AllToAllDevice {
             .set_two_qubit_gate_time(gate, control, target, gate_time)
     }
 
-    // /// Setting the gate time of a two qubit gate.
-    // ///
-    // /// # Arguments
-    // ///
-    // /// * `gate` - hqslang name of the two-qubit-gate.
-    // /// * `control_0` - The control_0 qubit for which the gate time is set.
-    // /// * `control_1` - The control_1 qubit for which the gate time is set.
-    // /// * `target` - The target qubit for which the gate time is set.
-    // /// * `gate_time` - gate time for the given gate.
-    // ///
-    // /// # Returns
-    // ///
-    // /// * `Ok(())` - The gate time was correctly set and nothing is returned
-    // /// * `Err(RoqoqoError::GenericError)` - Control_0 qubit set is larger than the number qubits in the device
-    // /// * `Err(RoqoqoError::GenericError)` - Control_1 qubit set is larger than the number qubits in the device
-    // /// * `Err(RoqoqoError::GenericError)` - Target qubit set is larger than the number qubits in the device
-    // pub fn set_three_qubit_gate_time(
-    //     &mut self,
-    //     gate: &str,
-    //     control_0: usize,
-    //     control_1: usize,
-    //     target: usize,
-    //     gate_time: f64,
-    // ) -> Result<(), RoqoqoError> {
-    //     self.generic_device
-    //         .set_three_qubit_gate_time(gate, control_0, control_1, target, gate_time)
-    // }
+    /// Setting the gate time of a two qubit gate.
+    ///
+    /// # Arguments
+    ///
+    /// * `gate` - hqslang name of the two-qubit-gate.
+    /// * `control_0` - The control_0 qubit for which the gate time is set.
+    /// * `control_1` - The control_1 qubit for which the gate time is set.
+    /// * `target` - The target qubit for which the gate time is set.
+    /// * `gate_time` - gate time for the given gate.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - The gate time was correctly set and nothing is returned
+    /// * `Err(RoqoqoError::GenericError)` - Control_0 qubit set is larger than the number qubits in the device
+    /// * `Err(RoqoqoError::GenericError)` - Control_1 qubit set is larger than the number qubits in the device
+    /// * `Err(RoqoqoError::GenericError)` - Target qubit set is larger than the number qubits in the device
+    pub fn set_three_qubit_gate_time(
+        &mut self,
+        gate: &str,
+        control_0: usize,
+        control_1: usize,
+        target: usize,
+        gate_time: f64,
+    ) -> Result<(), RoqoqoError> {
+        self.generic_device
+            .set_three_qubit_gate_time(gate, control_0, control_1, target, gate_time)
+    }
 
     /// Setting the gate time of a mulit qubit gate.
     ///
@@ -396,16 +396,16 @@ impl Device for AllToAllDevice {
             .two_qubit_gate_time(hqslang, control, target)
     }
 
-    // fn three_qubit_gate_time(
-    //     &self,
-    //     hqslang: &str,
-    //     control_0: &usize,
-    //     control_1: &usize,
-    //     target: &usize,
-    // ) -> Option<f64> {
-    //     self.generic_device
-    //         .three_qubit_gate_time(hqslang, control_0, control_1, target)
-    // }
+    fn three_qubit_gate_time(
+        &self,
+        hqslang: &str,
+        control_0: &usize,
+        control_1: &usize,
+        target: &usize,
+    ) -> Option<f64> {
+        self.generic_device
+            .three_qubit_gate_time(hqslang, control_0, control_1, target)
+    }
 
     fn multi_qubit_gate_time(&self, hqslang: &str, qubits: &[usize]) -> Option<f64> {
         self.generic_device.multi_qubit_gate_time(hqslang, qubits)

--- a/roqoqo/src/devices/generic_device.rs
+++ b/roqoqo/src/devices/generic_device.rs
@@ -232,62 +232,62 @@ impl GenericDevice {
         Ok(())
     }
 
-    // /// Setting the gate time of a three qubit gate.
-    // ///
-    // /// # Arguments
-    // ///
-    // /// * `gate` - hqslang name of the two-qubit-gate.
-    // /// * `control_0` - The control_0 qubit for which the gate time is set.
-    // /// * `control_1` - The control_1 qubit for which the gate time is set.
-    // /// * `target` - The target qubit for which the gate time is set.
-    // /// * `gate_time` - gate time for the given gate.
-    // pub fn set_three_qubit_gate_time(
-    //     &mut self,
-    //     gate: &str,
-    //     control_0: usize,
-    //     control_1: usize,
-    //     target: usize,
-    //     gate_time: f64,
-    // ) -> Result<(), RoqoqoError> {
-    //     if control_0 >= self.number_qubits {
-    //         return Err(RoqoqoError::GenericError {
-    //             msg: format!(
-    //                 "Qubit {} larger than number qubits {}",
-    //                 control_0, self.number_qubits
-    //             ),
-    //         });
-    //     }
-    //     if control_1 >= self.number_qubits {
-    //         return Err(RoqoqoError::GenericError {
-    //             msg: format!(
-    //                 "Qubit {} larger than number qubits {}",
-    //                 control_1, self.number_qubits
-    //             ),
-    //         });
-    //     }
-    //     if target >= self.number_qubits {
-    //         return Err(RoqoqoError::GenericError {
-    //             msg: format!(
-    //                 "Qubit {} larger than number qubits {}",
-    //                 target, self.number_qubits
-    //             ),
-    //         });
-    //     }
-    //     match self.three_qubit_gates.get_mut(gate) {
-    //         Some(gate_times) => {
-    //             let gatetime = gate_times
-    //                 .entry((control_0, control_1, target))
-    //                 .or_insert(gate_time);
-    //             *gatetime = gate_time;
-    //         }
-    //         None => {
-    //             let mut new_map = HashMap::new();
-    //             new_map.insert((control_0, control_1, target), gate_time);
-    //             self.three_qubit_gates.insert(gate.to_string(), new_map);
-    //         }
-    //     }
-    //     Ok(())
-    // }
+    /// Setting the gate time of a three qubit gate.
+    ///
+    /// # Arguments
+    ///
+    /// * `gate` - hqslang name of the two-qubit-gate.
+    /// * `control_0` - The control_0 qubit for which the gate time is set.
+    /// * `control_1` - The control_1 qubit for which the gate time is set.
+    /// * `target` - The target qubit for which the gate time is set.
+    /// * `gate_time` - gate time for the given gate.
+    pub fn set_three_qubit_gate_time(
+        &mut self,
+        gate: &str,
+        control_0: usize,
+        control_1: usize,
+        target: usize,
+        gate_time: f64,
+    ) -> Result<(), RoqoqoError> {
+        if control_0 >= self.number_qubits {
+            return Err(RoqoqoError::GenericError {
+                msg: format!(
+                    "Qubit {} larger than number qubits {}",
+                    control_0, self.number_qubits
+                ),
+            });
+        }
+        if control_1 >= self.number_qubits {
+            return Err(RoqoqoError::GenericError {
+                msg: format!(
+                    "Qubit {} larger than number qubits {}",
+                    control_1, self.number_qubits
+                ),
+            });
+        }
+        if target >= self.number_qubits {
+            return Err(RoqoqoError::GenericError {
+                msg: format!(
+                    "Qubit {} larger than number qubits {}",
+                    target, self.number_qubits
+                ),
+            });
+        }
+        match self.multi_qubit_gates.get_mut(gate) {
+            Some(gate_times) => {
+                let gatetime = gate_times
+                    .entry(vec![control_0, control_1, target])
+                    .or_insert(gate_time);
+                *gatetime = gate_time;
+            }
+            None => {
+                let mut new_map = HashMap::new();
+                new_map.insert(vec![control_0, control_1, target], gate_time);
+                self.multi_qubit_gates.insert(gate.to_string(), new_map);
+            }
+        }
+        Ok(())
+    }
 
     /// Setting the gate time of a multi qubit gate.
     ///
@@ -459,18 +459,21 @@ impl Device for GenericDevice {
         }
     }
 
-    // fn three_qubit_gate_time(
-    //     &self,
-    //     hqslang: &str,
-    //     control_0: &usize,
-    //     control_1: &usize,
-    //     target: &usize,
-    // ) -> Option<f64> {
-    //     match self.three_qubit_gates.get(&hqslang.to_string()) {
-    //         Some(x) => x.get(&(*control_0, *control_1, *target)).copied(),
-    //         None => None,
-    //     }
-    // }
+    fn three_qubit_gate_time(
+        &self,
+        hqslang: &str,
+        control_0: &usize,
+        control_1: &usize,
+        target: &usize,
+    ) -> Option<f64> {
+        match self.multi_qubit_gates.get(&hqslang.to_string()) {
+            Some(x) => {
+                let qubits: Vec<usize> = vec![*control_0, *control_1, *target];
+                x.get(&qubits).copied()
+            }
+            None => None,
+        }
+    }
 
     fn multi_qubit_gate_time(&self, hqslang: &str, qubits: &[usize]) -> Option<f64> {
         // variable unused in AllToAllDevice, is kept here for consistency purposes.

--- a/roqoqo/src/devices/mod.rs
+++ b/roqoqo/src/devices/mod.rs
@@ -76,27 +76,27 @@ pub trait Device {
     ///
     fn two_qubit_gate_time(&self, hqslang: &str, control: &usize, target: &usize) -> Option<f64>;
 
-    // /// Returns the gate time of a three qubit operation if the three qubit operation is available on device.
-    // ///
-    // /// # Arguments
-    // ///
-    // /// * `hqslang` - The hqslang name of a two qubit gate.
-    // /// * `control_0` - The control_0 qubit the gate acts on.
-    // /// * `control_1` - The control_1 qubit the gate acts on.
-    // /// * `target` - The target qubit the gate acts on.
-    // ///
-    // /// # Returns
-    // ///
-    // /// * `Some<f64>` - The gate time.
-    // /// * `None` - The gate is not available on the device.
-    // ///
-    // fn three_qubit_gate_time(
-    //     &self,
-    //     hqslang: &str,
-    //     control_0: &usize,
-    //     control_1: &usize,
-    //     target: &usize,
-    // ) -> Option<f64>;
+    /// Returns the gate time of a three qubit operation if the three qubit operation is available on device.
+    ///
+    /// # Arguments
+    ///
+    /// * `hqslang` - The hqslang name of a two qubit gate.
+    /// * `control_0` - The control_0 qubit the gate acts on.
+    /// * `control_1` - The control_1 qubit the gate acts on.
+    /// * `target` - The target qubit the gate acts on.
+    ///
+    /// # Returns
+    ///
+    /// * `Some<f64>` - The gate time.
+    /// * `None` - The gate is not available on the device.
+    ///
+    fn three_qubit_gate_time(
+        &self,
+        hqslang: &str,
+        control_0: &usize,
+        control_1: &usize,
+        target: &usize,
+    ) -> Option<f64>;
 
     /// Returns the gate time of a multi qubit operation if the multi qubit operation is available on device.
     ///

--- a/roqoqo/src/devices/square_lattice.rs
+++ b/roqoqo/src/devices/square_lattice.rs
@@ -241,31 +241,31 @@ impl SquareLatticeDevice {
         }
     }
 
-    // /// Setting the gate time of a three qubit gate.
-    // ///
-    // /// # Arguments
-    // ///
-    // /// * `gate` - hqslang name of the two-qubit-gate.
-    // /// * `control_0` - The control_0 qubit for which the gate time is set.
-    // /// * `control_1` - The control_1 qubit for which the gate time is set.
-    // /// * `target` - The target qubit for which the gate time is set.
-    // /// * `gate_time` - The gate time for the given gate.
-    // ///
-    // /// # Returns
-    // ///
-    // /// A SquareLatticeDevice with updated gate times.
-    // ///
-    // pub fn set_three_qubit_gate_time(
-    //     &mut self,
-    //     gate: &str,
-    //     control_0: usize,
-    //     control_1: usize,
-    //     target: usize,
-    //     gate_time: f64,
-    // ) -> Result<(), RoqoqoError> {
-    //     self.generic_device
-    //         .set_three_qubit_gate_time(gate, control_0, control_1, target, gate_time)
-    // }
+    /// Setting the gate time of a three qubit gate.
+    ///
+    /// # Arguments
+    ///
+    /// * `gate` - hqslang name of the two-qubit-gate.
+    /// * `control_0` - The control_0 qubit for which the gate time is set.
+    /// * `control_1` - The control_1 qubit for which the gate time is set.
+    /// * `target` - The target qubit for which the gate time is set.
+    /// * `gate_time` - The gate time for the given gate.
+    ///
+    /// # Returns
+    ///
+    /// A SquareLatticeDevice with updated gate times.
+    ///
+    pub fn set_three_qubit_gate_time(
+        &mut self,
+        gate: &str,
+        control_0: usize,
+        control_1: usize,
+        target: usize,
+        gate_time: f64,
+    ) -> Result<(), RoqoqoError> {
+        self.generic_device
+            .set_three_qubit_gate_time(gate, control_0, control_1, target, gate_time)
+    }
 
     /// Setting the gate time of a mulit qubit gate.
     ///
@@ -431,16 +431,16 @@ impl Device for SquareLatticeDevice {
             .two_qubit_gate_time(hqslang, control, target)
     }
 
-    // fn three_qubit_gate_time(
-    //     &self,
-    //     hqslang: &str,
-    //     control_0: &usize,
-    //     control_1: &usize,
-    //     target: &usize,
-    // ) -> Option<f64> {
-    //     self.generic_device
-    //         .three_qubit_gate_time(hqslang, control_0, control_1, target)
-    // }
+    fn three_qubit_gate_time(
+        &self,
+        hqslang: &str,
+        control_0: &usize,
+        control_1: &usize,
+        target: &usize,
+    ) -> Option<f64> {
+        self.generic_device
+            .three_qubit_gate_time(hqslang, control_0, control_1, target)
+    }
 
     fn multi_qubit_gate_time(&self, hqslang: &str, qubits: &[usize]) -> Option<f64> {
         self.generic_device.multi_qubit_gate_time(hqslang, qubits)

--- a/roqoqo/tests/integration/devices.rs
+++ b/roqoqo/tests/integration/devices.rs
@@ -73,13 +73,13 @@ fn test_all_to_all() {
     device.set_two_qubit_gate_time("CNOT", 0, 1, 0.5).unwrap();
     assert_eq!(device.two_qubit_gate_time("CNOT", &0, &1), Some(0.5f64));
 
-    // device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 0.5_f64)
-    //     .unwrap();
-    // assert_eq!(
-    //     device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &2),
-    //     Some(0.5_f64)
-    // );
+    device
+        .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 0.5_f64)
+        .unwrap();
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &2),
+        Some(0.5_f64)
+    );
 
     device
         .set_single_qubit_gate_time("RotateX", 2, 0.07)
@@ -120,21 +120,21 @@ fn generic_device_works() {
     assert!(device.set_two_qubit_gate_time("CNOT", 30, 2, 0.5).is_err());
     assert!(device.set_two_qubit_gate_time("CNOT", 2, 20, 0.5).is_err());
 
-    // device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 0.5)
-    //     .unwrap();
-    // device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 2, 1, 0, 0.5)
-    //     .unwrap();
-    // device
-    //     .set_three_qubit_gate_time("ControlledControlledPhaseShift", 0, 1, 2, 0.5)
-    //     .unwrap();
-    // assert!(device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 25, 1, 11, 0.5)
-    //     .is_err());
-    // assert!(device
-    //     .set_three_qubit_gate_time("ControlledControlledPhaseShift", 21, 14, 12, 0.5)
-    //     .is_err());
+    device
+        .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 0.5)
+        .unwrap();
+    device
+        .set_three_qubit_gate_time("ControlledControlledPauliZ", 2, 1, 0, 0.5)
+        .unwrap();
+    device
+        .set_three_qubit_gate_time("ControlledControlledPhaseShift", 0, 1, 2, 0.5)
+        .unwrap();
+    assert!(device
+        .set_three_qubit_gate_time("ControlledControlledPauliZ", 25, 1, 11, 0.5)
+        .is_err());
+    assert!(device
+        .set_three_qubit_gate_time("ControlledControlledPhaseShift", 21, 14, 12, 0.5)
+        .is_err());
 
     device
         .set_multi_qubit_gate_time("MultiQubitMS", vec![0, 1, 2], 0.8)
@@ -204,18 +204,18 @@ fn generic_device_works() {
     assert_eq!(device.two_qubit_gate_time("CNOT", &0, &3), None);
     assert_eq!(device.two_qubit_gate_time("CZ", &0, &1), None);
 
-    // assert_eq!(
-    //     device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &2),
-    //     Some(0.5)
-    // );
-    // assert_eq!(
-    //     device.three_qubit_gate_time("ControlledControlledPauliZ", &2, &1, &0),
-    //     Some(0.5)
-    // );
-    // assert_eq!(
-    //     device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &1, &2),
-    //     Some(0.5)
-    // );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &2),
+        Some(0.5)
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &2, &1, &0),
+        Some(0.5)
+    );
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPhaseShift", &0, &1, &2),
+        Some(0.5)
+    );
 
     assert_eq!(
         device.multi_qubit_gate_time("MultiQubitMS", &[0, 1, 2]),
@@ -269,9 +269,6 @@ fn all_to_all_generic() {
     generic_device
         .set_two_qubit_gate_time("CNOT", 1, 0, 1.0)
         .unwrap();
-    // generic_device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 1.0)
-    //     .unwrap();
     // setting the decoherence rates directly
     generic_device
         .set_qubit_decoherence_rates(0, array![[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
@@ -320,9 +317,6 @@ fn square_lattice_generic() {
     generic_device
         .set_two_qubit_gate_time("CNOT", 1, 0, 1.0)
         .unwrap();
-    // generic_device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 1.0)
-    //     .unwrap();
     // setting the decoherence rates directly
     generic_device
         .set_qubit_decoherence_rates(0, array![[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
@@ -382,13 +376,13 @@ fn test_square_lattice() {
     assert_eq!(device.single_qubit_gate_time("RotateX", &0), Some(0.2f64));
     assert_eq!(device.two_qubit_gate_time("CNOT", &0, &1), Some(0.2f64));
 
-    // device
-    //     .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 0.8)
-    //     .unwrap();
-    // assert_eq!(
-    //     device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &2),
-    //     Some(0.8),
-    // );
+    device
+        .set_three_qubit_gate_time("ControlledControlledPauliZ", 0, 1, 2, 0.8)
+        .unwrap();
+    assert_eq!(
+        device.three_qubit_gate_time("ControlledControlledPauliZ", &0, &1, &2),
+        Some(0.8),
+    );
 
     device
         .set_multi_qubit_gate_time("MultiQubitMS", vec![0, 1, 2], 0.8)


### PR DESCRIPTION
This adds Device support for 3-qubit operations without the need of breaking changes.

Signatures are unchanged and the newly written `set_three_qubit_gate_time` and `three_qubit_gate_time` store the gate information in the internal multi-qubit gate vector.