### PR TITLE
Version Check Qoqo Support

### DIFF
--- a/qoqo-macros/src/lib.rs
+++ b/qoqo-macros/src/lib.rs
@@ -529,11 +529,31 @@ pub fn wrap(
     let json_schema_quote = if attribute_arguments.contains("JsonSchema") {
         quote! {
             #[cfg(feature = "json_schema")]
+            /// Returns the current version of the qoqo library .
+            ///
+            /// Returns:
+            ///     str: The current version of the library.
             #[staticmethod]
+            pub fn current_version() -> String {
+                ROQOQO_VERSION.to_string()
+            }
+
+            #[cfg(feature = "json_schema")]
+            /// Return the minimum version of qoqo that supports this object.
+            ///
+            /// Returns:
+            ///     str: The minimum version of the qoqo library to deserialize this object.
+            pub fn min_supported_version(&self) -> String {
+                let min_version: (u32, u32, u32) = #ident::minimum_supported_roqoqo_version(&self.internal);
+                format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
+            }
+
+            #[cfg(feature = "json_schema")]
             /// Return the JsonSchema for the json serialisation of the class.
             ///
             /// Returns:
             ///     str: The json schema serialized to json
+            #[staticmethod]
             pub fn json_schema() -> String {
                 let schema = schemars::schema_for!(#ident);
                 serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")

--- a/qoqo/src/circuit.rs
+++ b/qoqo/src/circuit.rs
@@ -310,6 +310,27 @@ impl CircuitWrapper {
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
     }
 
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            Circuit::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
+    }
+
     #[staticmethod]
     /// Convert the json representation of a Circuit to a Circuit.
     ///

--- a/qoqo/src/measurements/basis_rotation_measurement.rs
+++ b/qoqo/src/measurements/basis_rotation_measurement.rs
@@ -22,7 +22,9 @@ use roqoqo::measurements::PauliZProduct;
 use roqoqo::prelude::*;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::Circuit;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
+
 #[pyclass(name = "PauliZProduct", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a measurement of PauliZ product.
@@ -331,14 +333,35 @@ impl PauliZProductWrapper {
     }
 
     #[cfg(feature = "json_schema")]
-    #[staticmethod]
     /// Return the JsonSchema for the json serialisation of the class.
     ///
     /// Returns:
     ///     str: The json schema serialized to json
+    #[staticmethod]
     pub fn json_schema() -> String {
         let schema = schemars::schema_for!(PauliZProduct);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            PauliZProduct::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
     }
 }
 

--- a/qoqo/src/measurements/cheated_basis_rotation_measurement.rs
+++ b/qoqo/src/measurements/cheated_basis_rotation_measurement.rs
@@ -22,7 +22,9 @@ use roqoqo::measurements::CheatedPauliZProduct;
 use roqoqo::prelude::*;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::Circuit;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
+
 #[pyclass(name = "CheatedPauliZProduct", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a cheated measurement of PauliZ product.
@@ -330,14 +332,35 @@ impl CheatedPauliZProductWrapper {
     }
 
     #[cfg(feature = "json_schema")]
-    #[staticmethod]
     /// Return the JsonSchema for the json serialisation of the class.
     ///
     /// Returns:
     ///     str: The json schema serialized to json
+    #[staticmethod]
     pub fn json_schema() -> String {
         let schema = schemars::schema_for!(CheatedPauliZProduct);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            CheatedPauliZProduct::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
     }
 }
 

--- a/qoqo/src/measurements/cheated_measurement.rs
+++ b/qoqo/src/measurements/cheated_measurement.rs
@@ -22,7 +22,9 @@ use roqoqo::measurements::Cheated;
 use roqoqo::prelude::*;
 use roqoqo::registers::{BitOutputRegister, ComplexOutputRegister, FloatOutputRegister};
 use roqoqo::Circuit;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
+
 #[pyclass(name = "Cheated", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a cheated measurement.
@@ -337,6 +339,27 @@ impl CheatedWrapper {
     pub fn json_schema() -> String {
         let schema = schemars::schema_for!(Cheated);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            Cheated::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
     }
 }
 

--- a/qoqo/src/measurements/classical_register_measurement.rs
+++ b/qoqo/src/measurements/classical_register_measurement.rs
@@ -20,7 +20,9 @@ use pyo3::types::PyByteArray;
 use roqoqo::measurements::ClassicalRegister;
 use roqoqo::prelude::*;
 use roqoqo::Circuit;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
+
 #[pyclass(name = "ClassicalRegister", module = "qoqo.measurements")]
 #[derive(Clone, Debug)]
 /// Collected information for executing a classical register.
@@ -260,6 +262,27 @@ impl ClassicalRegisterWrapper {
     pub fn json_schema() -> String {
         let schema = schemars::schema_for!(ClassicalRegister);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            ClassicalRegister::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
     }
 }
 

--- a/qoqo/src/measurements/measurement_auxiliary_data_input.rs
+++ b/qoqo/src/measurements/measurement_auxiliary_data_input.rs
@@ -20,6 +20,8 @@ use pyo3::types::PyByteArray;
 use roqoqo::measurements::{
     CheatedInput, CheatedPauliZProductInput, PauliProductMask, PauliZProductInput,
 };
+use roqoqo::operations::SupportedVersion;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[pyclass(name = "PauliZProductInput", module = "qoqo.measurements")]
@@ -229,6 +231,27 @@ impl PauliZProductInputWrapper {
         let schema = schemars::schema_for!(PauliZProductInput);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
     }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            PauliZProductInput::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
+    }
 }
 
 #[pyclass(name = "CheatedPauliZProductInput", module = "qoqo.measurements")]
@@ -432,6 +455,27 @@ impl CheatedPauliZProductInputWrapper {
         let schema = schemars::schema_for!(CheatedPauliZProductInput);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
     }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            CheatedPauliZProductInput::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
+    }
 }
 
 #[pyclass(name = "CheatedInput", module = "qoqo.measurements")]
@@ -597,6 +641,27 @@ impl CheatedInputWrapper {
     pub fn json_schema() -> String {
         let schema = schemars::schema_for!(CheatedInput);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            CheatedInput::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
     }
 }
 

--- a/qoqo/src/operations/bosonic_operations.rs
+++ b/qoqo/src/operations/bosonic_operations.rs
@@ -17,6 +17,7 @@ use qoqo_calculator::CalculatorFloat;
 use qoqo_calculator_pyo3::{convert_into_calculator_float, CalculatorFloatWrapper};
 use qoqo_macros::*;
 use roqoqo::operations::*;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[wrap(

--- a/qoqo/src/operations/define_operations.rs
+++ b/qoqo/src/operations/define_operations.rs
@@ -15,6 +15,7 @@ use pyo3::prelude::*;
 use pyo3::types::PySet;
 use qoqo_macros::*;
 use roqoqo::operations::*;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[wrap(Operate, Define, JsonSchema)]

--- a/qoqo/src/operations/measurement_operations.rs
+++ b/qoqo/src/operations/measurement_operations.rs
@@ -16,6 +16,7 @@ use pyo3::types::PySet;
 use qoqo_macros::*;
 use roqoqo::operations::*;
 use roqoqo::Circuit;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[wrap(Operate, OperateSingleQubit, JsonSchema)]

--- a/qoqo/src/operations/multi_qubit_gate_operations.rs
+++ b/qoqo/src/operations/multi_qubit_gate_operations.rs
@@ -21,6 +21,7 @@ use qoqo_calculator_pyo3::convert_into_calculator_float;
 use qoqo_calculator_pyo3::CalculatorFloatWrapper;
 use qoqo_macros::*;
 use roqoqo::operations::*;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[allow(clippy::upper_case_acronyms)]

--- a/qoqo/src/operations/pragma_operations.rs
+++ b/qoqo/src/operations/pragma_operations.rs
@@ -23,6 +23,7 @@ use qoqo_calculator_pyo3::{convert_into_calculator_float, CalculatorFloatWrapper
 use qoqo_macros::*;
 use roqoqo::operations::*;
 use roqoqo::Circuit;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 /// Wrap function automatically generates functions in these traits.

--- a/qoqo/src/operations/single_qubit_gate_operations.rs
+++ b/qoqo/src/operations/single_qubit_gate_operations.rs
@@ -19,6 +19,7 @@ use qoqo_calculator::CalculatorFloat;
 use qoqo_calculator_pyo3::{convert_into_calculator_float, CalculatorFloatWrapper};
 use qoqo_macros::*;
 use roqoqo::operations::*;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[wrap(

--- a/qoqo/src/operations/three_qubit_gate_operations.rs
+++ b/qoqo/src/operations/three_qubit_gate_operations.rs
@@ -21,6 +21,7 @@ use qoqo_calculator::CalculatorFloat;
 use qoqo_calculator_pyo3::{convert_into_calculator_float, CalculatorFloatWrapper};
 
 use roqoqo::operations::*;
+use roqoqo::ROQOQO_VERSION;
 
 use std::collections::HashMap;
 

--- a/qoqo/src/operations/two_qubit_gate_operations.rs
+++ b/qoqo/src/operations/two_qubit_gate_operations.rs
@@ -19,6 +19,7 @@ use qoqo_calculator::CalculatorFloat;
 use qoqo_calculator_pyo3::{convert_into_calculator_float, CalculatorFloatWrapper};
 use qoqo_macros::*;
 use roqoqo::operations::*;
+use roqoqo::ROQOQO_VERSION;
 use std::collections::HashMap;
 
 #[allow(clippy::upper_case_acronyms)]

--- a/qoqo/src/quantum_program.rs
+++ b/qoqo/src/quantum_program.rs
@@ -21,6 +21,7 @@ use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyByteArray;
 use roqoqo::measurements::Measure;
+use roqoqo::operations::SupportedVersion;
 use roqoqo::QuantumProgram;
 use roqoqo::ROQOQO_VERSION;
 
@@ -407,6 +408,27 @@ impl QuantumProgramWrapper {
     pub fn json_schema() -> String {
         let schema = schemars::schema_for!(QuantumProgram);
         serde_json::to_string_pretty(&schema).expect("Unexpected failure to serialize schema")
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Returns the current version of the qoqo library .
+    ///
+    /// Returns:
+    ///     str: The current version of the library.
+    #[staticmethod]
+    pub fn current_version() -> String {
+        ROQOQO_VERSION.to_string()
+    }
+
+    #[cfg(feature = "json_schema")]
+    /// Return the minimum version of qoqo that supports this object.
+    ///
+    /// Returns:
+    ///     str: The minimum version of the qoqo library to deserialize this object.
+    pub fn min_supported_version(&self) -> String {
+        let min_version: (u32, u32, u32) =
+            QuantumProgram::minimum_supported_roqoqo_version(&self.internal);
+        format!("{}.{}.{}", min_version.0, min_version.1, min_version.2)
     }
 
     /// Return the __richcmp__ magic method to perform rich comparison operations on QuantumProgram.


### PR DESCRIPTION
Adds methods `min_supported_version` and `current_version` to qoqo.
Part of the `json_schema` feature.

WIP: still to be tested.