### PR TITLE
Adding `strum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 This changelog track changes to the qoqo project starting at version v0.5.0
 
 
-## Unrelead
+## Unreleased
 
-### Added in Unrelease
+### Added in Unreleased
 
 * Added possibility of iterating through gate enums in Roqoqo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog track changes to the qoqo project starting at version v0.5.0
 
+
+## Unrelead
+
+### Added in Unrelease
+
+* Added possibility of iterating through gate enums in Roqoqo
+
 ## 1.15.2-alpha.5
 
 ### Added in 1.15.2-alpha.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -510,6 +510,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1098,7 +1104,7 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -1322,6 +1328,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "strum",
+ "strum_macros",
  "struqture 1.9.2",
  "syn",
  "test-case",
@@ -1363,6 +1371,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -1522,6 +1536,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "struqture"

--- a/roqoqo/Cargo.toml
+++ b/roqoqo/Cargo.toml
@@ -40,6 +40,8 @@ futures = { version = "0.3", optional = true }
 petgraph = { version = "0.6.2", optional = true }
 bincode = { version = "1.3", optional = true }
 struqture = { version = "~1.9", features = ["json_schema"] }
+strum = { version = "0.26" }
+strum_macros = { version = "0.26" }
 
 [dev-dependencies]
 serde_test = "1.0"
@@ -51,6 +53,8 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full", "visit"] }
 proc-macro2 = "1.0"
 rand = { version = "~0.8" }
+strum = { version = "0.26" }
+strum_macros = { version = "0.26" }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--document-private-items"]

--- a/roqoqo/build.rs
+++ b/roqoqo/build.rs
@@ -620,7 +620,7 @@ fn main() {
     // Construct TokenStream for auto-generated rust file containing the enums
     let final_quote = quote! {
 
-        //use crate::operations::*;
+        use strum_macros::EnumIter;
 
         /// Enum of all Operations implementing [Operate]
         #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, Substitute, SupportedVersion)]
@@ -696,7 +696,7 @@ fn main() {
         }
 
         /// Enum of all Operations implementing [OperateGate]
-        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate,  SupportedVersion)]
+        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate,  SupportedVersion, EnumIter)]
         #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
         #[non_exhaustive]
@@ -733,7 +733,7 @@ fn main() {
         }
 
         /// Enum of all Operations implementing [OperateSingleQubitGate]
-        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateSingleQubit, OperateSingleQubitGate,  SupportedVersion)]
+        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateSingleQubit, OperateSingleQubitGate,  SupportedVersion, EnumIter)]
         #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
         #[non_exhaustive]
@@ -742,7 +742,7 @@ fn main() {
         }
 
         /// Enum of all Operations implementing [OperateTwoQubitGate]
-        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateTwoQubit, OperateTwoQubitGate,  SupportedVersion)]
+        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateTwoQubit, OperateTwoQubitGate,  SupportedVersion, EnumIter)]
         #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
         #[non_exhaustive]
@@ -751,7 +751,7 @@ fn main() {
         }
 
         /// Enum of all Operations implementing [OperateThreeQubitGate]
-        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateThreeQubit, OperateThreeQubitGate,  SupportedVersion)]
+        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateThreeQubit, OperateThreeQubitGate,  SupportedVersion, EnumIter)]
         #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
         #[non_exhaustive]
@@ -760,7 +760,7 @@ fn main() {
         }
 
         /// Enum of all Operations implementing [OperateMultiQubitGate]
-        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateMultiQubit, OperateMultiQubitGate, SupportedVersion)]
+        #[derive(Debug, Clone, PartialEq, InvolveQubits, Operate, OperateTryFromEnum, Substitute, OperateGate, OperateMultiQubit, OperateMultiQubitGate, SupportedVersion, EnumIter)]
         #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
         #[non_exhaustive]

--- a/roqoqo/src/operations/multi_qubit_gate_operations.rs
+++ b/roqoqo/src/operations/multi_qubit_gate_operations.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 /// In mathematical terms the gate applies exp(-i * θ/2 * X_i0 * X_i1 * ... * X_in).
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -98,6 +99,7 @@ impl OperateMultiQubitGate for MultiQubitMS {
 /// In mathematical terms the gate applies exp(-i * θ/2 * Z_i0 * Z_i1 * ... * Z_in).
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,

--- a/roqoqo/src/operations/single_qubit_gate_operations.rs
+++ b/roqoqo/src/operations/single_qubit_gate_operations.rs
@@ -32,6 +32,7 @@ use rand_distr::{Distribution, Normal};
 /// is always normalized to one.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -158,6 +159,7 @@ impl OperateSingleQubitGate for SingleQubitGate {
 /// The ZPower gate exp(-i * θ/2 * σ^z).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -255,6 +257,7 @@ impl OperateSingleQubitGate for RotateZ {
 /// The XPower gate exp(-i * θ/2 * σ^x).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -347,6 +350,7 @@ impl OperateSingleQubitGate for RotateX {
 /// The YPower gate exp(-i * θ/2 * σ^y).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -439,6 +443,7 @@ impl OperateSingleQubitGate for RotateY {
 /// The Pauli X gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -527,6 +532,7 @@ impl OperateSingleQubitGate for PauliX {
 /// The Pauli Y gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -615,6 +621,7 @@ impl OperateSingleQubitGate for PauliY {
 /// The Pauli Z gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -703,6 +710,7 @@ impl OperateSingleQubitGate for PauliZ {
 /// The square root of the XPower gate exp(-i * π/4 * σ^x).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -794,6 +802,7 @@ impl OperateSingleQubitGate for SqrtPauliX {
 /// The inverse square root of the XPower gate: exp(i * π/4 * σ^x).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -885,6 +894,7 @@ impl OperateSingleQubitGate for InvSqrtPauliX {
 /// The Hadamard gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -974,6 +984,7 @@ impl OperateSingleQubitGate for Hadamard {
 /// The S gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1062,6 +1073,7 @@ impl OperateSingleQubitGate for SGate {
 /// The T gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1155,6 +1167,7 @@ impl OperateSingleQubitGate for TGate {
 /// Rotation around Z-axis by an arbitrary angle θ (AC Stark shift of the state |1>).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1252,6 +1265,7 @@ impl OperateSingleQubitGate for PhaseShiftState1 {
 /// Rotation around Z-axis by an arbitrary angle θ (AC Stark shift of the state |0>).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1347,6 +1361,7 @@ impl OperateSingleQubitGate for PhaseShiftState0 {
 /// Implements a rotation around an axis in the x-y plane in spherical coordinates.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1463,6 +1478,7 @@ impl OperateSingleQubitGate for RotateAroundSphericalAxis {
 /// Implements a rotation around an x- and y-axis in spherical coordinates.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1570,6 +1586,7 @@ impl OperateSingleQubitGate for RotateXY {
 /// Implements a pi-rotation with an embedded phase.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1670,6 +1687,7 @@ impl OperateSingleQubitGate for GPi {
 /// Implements a pi/2-rotation with an embedded phase.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1769,6 +1787,7 @@ impl OperateSingleQubitGate for GPi2 {
 /// The Identity gate.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1864,6 +1883,7 @@ impl OperateSingleQubitGate for Identity {
 /// The square root of the PauliY gate exp(-i * π/4 * σ^y).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1962,6 +1982,7 @@ impl OperateSingleQubitGate for SqrtPauliY {
 /// The inverse square root of the YPower gate: exp(i * π/4 * σ^x).
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,

--- a/roqoqo/src/operations/three_qubit_gate_operations.rs
+++ b/roqoqo/src/operations/three_qubit_gate_operations.rs
@@ -28,6 +28,7 @@ use rand_distr::{Distribution, Normal};
 /// depending on the states of both `control_0` and `control_1` qubits.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -179,6 +180,7 @@ impl OperateThreeQubitGate for ControlledControlledPauliZ {
 /// depending on the states of both `control_0` and `control_1` qubits.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -333,6 +335,7 @@ impl OperateThreeQubitGate for ControlledControlledPhaseShift {
 /// depending on the states of both `control_0` and `control_1` qubits.
 ///
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,

--- a/roqoqo/src/operations/two_qubit_gate_operations.rs
+++ b/roqoqo/src/operations/two_qubit_gate_operations.rs
@@ -51,6 +51,7 @@ pub struct KakDecomposition {
 /// Flips the state of a `target` qubit based on the `control` qubit.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -150,6 +151,7 @@ impl OperateTwoQubitGate for CNOT {
 /// Swaps the states of two qubits `target` and `control`.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -242,6 +244,7 @@ impl OperateTwoQubitGate for SWAP {
 /// and applies a complex phase `i` to states |01> and |10>.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -335,6 +338,7 @@ impl OperateTwoQubitGate for ISwap {
 /// Conserves the correct sign when the qubits represent Fermionic degrees of freedom.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -431,6 +435,7 @@ impl OperateTwoQubitGate for FSwap {
 /// SqrtISwap * SqrtISwap = ISwap
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -523,6 +528,7 @@ impl OperateTwoQubitGate for SqrtISwap {
 /// InvSqrtISwap * SqrtISwap = Identity
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -617,6 +623,7 @@ impl OperateTwoQubitGate for InvSqrtISwap {
 /// XY = exp(i * (X_target * X_control + Y_target * Y_control) * theta / 2)
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -715,6 +722,7 @@ impl OperateTwoQubitGate for XY {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -816,6 +824,7 @@ impl OperateTwoQubitGate for ControlledPhaseShift {
 /// Applies a PauliY unitary to the `target` qubit depending on the state of the `control`
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -915,6 +924,7 @@ impl OperateTwoQubitGate for ControlledPauliY {
 /// Applies a PauliZ unitary to the `target` qubit depending on the state of the `control` qubit.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1010,6 +1020,7 @@ impl OperateTwoQubitGate for ControlledPauliZ {
 /// Applies the unitary exp(-1 X_control X_target * pi/4) to two qubits `control` and `target`
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1102,6 +1113,7 @@ impl OperateTwoQubitGate for MolmerSorensenXX {
 /// Applies the unitary exp(-1 X_control X_target * theta/2) to two qubits `control` and `target`
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1200,6 +1212,7 @@ impl OperateTwoQubitGate for VariableMSXX {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1309,6 +1322,7 @@ impl OperateTwoQubitGate for GivensRotation {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1419,6 +1433,7 @@ impl OperateTwoQubitGate for GivensRotationLittleEndian {
 /// exp(-i (x * X_c X_t + y * Y_c Y_t + z * Z_c Z_t))
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1536,6 +1551,7 @@ impl OperateTwoQubitGate for Qsim {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1642,6 +1658,7 @@ impl OperateTwoQubitGate for Fsim {
 /// exp(-i (x * X_t X_c + y * Y_t Y_c + z * Z_t Z_c))
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1755,6 +1772,7 @@ impl OperateTwoQubitGate for SpinInteraction {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1867,6 +1885,7 @@ impl OperateTwoQubitGate for Bogoliubov {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -1964,6 +1983,7 @@ impl OperateTwoQubitGate for PMInteraction {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -2070,6 +2090,7 @@ impl OperateTwoQubitGate for ComplexPMInteraction {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -2176,6 +2197,7 @@ impl OperateTwoQubitGate for PhaseShiftedControlledZ {
 ///
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -2292,6 +2314,7 @@ impl OperateTwoQubitGate for PhaseShiftedControlledPhase {
 /// Implements the controlled RotateX operation.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -2400,6 +2423,7 @@ impl OperateTwoQubitGate for ControlledRotateX {
 /// Implements the controlled RotateX operation.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,
@@ -2513,6 +2537,7 @@ impl OperateTwoQubitGate for ControlledRotateXY {
 /// Implements the controlled RotateX operation.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(
+    Default,
     Debug,
     Clone,
     PartialEq,


### PR DESCRIPTION
This adds the possibility of iterating through an enum in Roqoqo:
```rust
use strum::IntoEnumIterator;

for gate in TwoQubitGateOperation::iter() {
    println!("{:?}", gate.hqslang());
}
```