### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,69 +2,6 @@
 
 # qoqo
 
-Quantum Operation Quantum Operation  
-Yes we use [reduplication](https://en.wikipedia.org/wiki/Reduplication)
-
-qoqo/roqoqo is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de).
-
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
-
-<img src="./documentation/src/images/Introduction_Graphics.png" alt="qoqo" width="70%">
-
-What roqoqo/qoqo is:
-
-* A toolkit to represent quantum programs including circuits and measurement information
-* A thin runtime to run quantum measurements
-* A way to serialize quantum circuits and measurement information
-* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_mock](https://github.com/HQSquantumsimulations/qoqo_mock), [qoqo_qasm](https://github.com/HQSquantumsimulations/qoqo_qasm))
-
-What roqoqo/qoqo is **not**:
-
-* A decomposer translating circuits to a specific set of gates
-* A quantum circuit optimizer
-* A collection of quantum algorithms
-
-This repository contains two components:
-
-* roqoqo: the core rust library
-* qoqo: the python interface to roqoqo
-
-## roqoqo
-
-[![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/roqoqo)
-![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/actions/workflows/hqs-ci-test-rust-pyo3.yml/badge.svg)
-[![docs.rs](https://img.shields.io/docsrs/roqoqo)](https://docs.rs/roqoqo/)
-![Crates.io](https://img.shields.io/crates/l/roqoqo)
-[![codecov](https://codecov.io/gh/HQSquantumsimulations/qoqo/branch/main/graph/badge.svg?token=S1IN066V2W)](https://codecov.io/gh/HQSquantumsimulations/qoqo)
-
-roqoqo provides:
-
-* A `Circuit` struct to represent quantum circuits
-* A `QuantumProgram` enum to represent quantum programs using different measurement methods
-* Structs representing single-qubit, two-qubit, multi-qubit and measurement operations that can be executed (decomposed) on any universal quantum computer
-* Structs representing so-called PRAGMA operations that only apply to certain hardware, simulators or annotate circuits with additional information
-* Enums that group operations based on the properties of operations (*e.g.* `Operation` for all operations or `SingleQubitGateOperation` for all unitary operations acting on a single qubit)
-* Support for symbolic variables
-* Readout based on classical registers
-* Measurement structs for evaluating observable measurements based on raw readout date returned by quantum computer backends
-* An `EvaluatingBackend` trait defining a standard for interfacing from qoqo to hardware and simulators that can return measured values
-* A `Device` trait defining a standard to obtain connectivity information and a noise model for quantum computing devices
-* Serialize and deserialize support for `Circuit` and `QuantumProgram` via the serde crate.
-
-This software is still in the beta stage. Functions and documentation are not yet complete and breaking changes can occur.
-
-### Installation
-
-To use roqoqo in a Rust project simply add
-
-```TOML
-roqoqo = {version="1.0"}
-```
-
-to the `[dependencies]` section of the project Cargo.toml.
-
-## qoqo
-
 [![Documentation Status](https://img.shields.io/badge/docs-read-blue)](https://hqsquantumsimulations.github.io/qoqo/)
 ![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/actions/workflows/hqs-ci-test-rust-pyo3.yml/badge.svg)
 [![PyPI](https://img.shields.io/pypi/v/qoqo)](https://pypi.org/project/qoqo/)
@@ -72,24 +9,42 @@ to the `[dependencies]` section of the project Cargo.toml.
 [![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/qoqo)
 ![Crates.io](https://img.shields.io/crates/l/qoqo)
 
-qoqo provides the Python interface to the underlying roqoqo library, including:
+**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of reduplication. 
 
-* A `Circuit` class to represent quantum circuits
-* A `QuantumProgram` class to represent quantum programs 
-* Classes representing single-qubit, two-qubit, multi-qubit and measurement operations that can be executed (decomposed) on any universal quantum computer
-* Classes representing so-called PRAGMA operations that only apply to certain hardware, simulators or annotate circuits with additional information
-* Support for symbolic variables
-* Readout based on classical registers
-* Measurement classes for evaluating observable measurements based on raw readout date returned by quantum computer backends
-* Serialization to json and deserialization from json for circuits and measurement information. Serialization support can easily be expanded to other targets with the help of the serde crate.
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
 
-### Installation
+<img src="./documentation/src/images/Introduction_Graphics.png" alt="qoqo" width="70%">
+
+What qoqo is:
+
+* A toolkit to represent quantum programs including circuits and measurement information.
+* A thin runtime to run quantum measurements.
+* A way to serialize quantum circuits and measurement information.
+* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_qiskit](https://github.com/HQSquantumsimulations/qoqo-qiskit), [qoqo_for_braket](https://github.com/HQSquantumsimulations/qoqo-for-braket), [qoqo_iqm](https://github.com/HQSquantumsimulations/qoqo_iqm)).
+
+What qoqo is **not**:
+
+* A decomposer translating circuits to a specific set of gates
+* A quantum circuit optimizer
+* A collection of quantum algorithms
+
+If you are looking for a comprehensive package that integrates all these features, we invite you to explore our [HQStage](https://cloud.quantumsimulations.de/) software.
+
+This repository contains two components:
+
+* qoqo: the python interface to roqoqo, described here.
+* roqoqo: the core rust library. Further details are provided in the individual README file [here](./roqoqo/README_roqoqo.md).
+
+
+## Installation
 
 On Linux, macOS and Windows on x86 precompiled packages can be found on PyPi and installed via
 
 ```shell
 pip install qoqo
 ```
+
+### Installing from source (optional)
 
 If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain (for example available via rustup) and maturin (also available via pip). After installing the rust toolchain and maturing run the same pip install command as above. In some cases on macOS it can be necessary to provide specific linker arguments as shown below:
 
@@ -103,24 +58,43 @@ RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -m q
 pip install target/wheels/$NAME_OF_WHEEL
 ```
 
-When using qoqo in a rust project providing a python interface add
+## Create your first circuit in qoqo
 
-```TOML
-qoqo = {version="1.0", default-features=false}
+The following code snippet can be used to create your first circuit in qoqo. For an expanded collection of **examples** please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). 
+
+```python
+from qoqo import Circuit
+from qoqo import operations as ops
+from qoqo_quest import Backend
+
+circuit = Circuit()
+circuit += ops.DefinitionBit(name="classical_reg", length=2, is_output=True)
+circuit += ops.PauliX(qubit=0)
+circuit += ops.CNOT(0,1)
+circuit += ops.PragmaDamping(qubit=0, gate_time=0.1, rate=0.1)
+circuit += ops.PragmaDamping(qubit=1, gate_time=0.1, rate=0.1)
+circuit += ops.MeasureQubit(qubit=0, readout="classical_reg", readout_index=0)
+circuit += ops.MeasureQubit(qubit=1, readout="classical_reg", readout_index=1)
+circuit += ops.PragmaSetNumberOfMeasurements(number_measurements=1000, readout="classical_reg")
+
+backend = Backend(number_qubits=2)
+bit_registers, float_registers, complex_registers = backend.run_circuit(circuit)
 ```
 
-to the `[dependencies]` section of the project Cargo.toml.
+## Features
 
-A source distribution now exists but requires a Rust install with a rust version > 1.47 and a maturin version { >= 0.12, <0.13 } in order to be built.
+**qoqo** provides the following functionalities and features:
 
-### Examples
+* A `Circuit` class to represent quantum circuits
+* A `QuantumProgram` class to represent quantum programs 
+* Classes representing single-qubit, two-qubit, multi-qubit and measurement operations that can be executed (decomposed) on any universal quantum computer
+* Classes representing so-called PRAGMA operations that only apply to certain hardware, simulators or annotate circuits with additional information
+* Support for symbolic variables
+* Readout based on classical registers
+* Measurement classes for evaluating observable measurements based on raw readout date returned by quantum computer backends
+* Serialization to json and deserialization from json for circuits and measurement information. Serialization support can easily be expanded to other targets with the help of the serde crate.
 
-Since qoqo provides a full python interface to the underlying roqoqo library, there are examples for python users and for Rust users.
-
-For an expanded collection of examples please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). The qoqo examples require the qoqo_quest and qoqo_mock interfaces.
-
-* **qoqo examples**: For jupyter notebooks in **python**, please refer to [qoqo_examples/qoqo/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/qoqo).
-* **roqoqo examples**: The jupyter notebooks in **Rust** can be found in [qoqo_examples/roqoqo/notebooks/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/roqoqo/notebooks). Alternatively, you can also find pure **Rust** versions of the examples in [qoqo_examples/roqoqo/standalone/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/roqoqo/standalone)
+## Support
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).
 
@@ -129,3 +103,16 @@ This project has been partly supported by [PlanQK](https://planqk.de) and is par
 We welcome contributions to the project. If you want to contribute code, please have a look at CONTRIBUTE.md for our code contribution guidelines.
 
 In order to facilitate the contribution of the addition of a new gate, please also have a look at add_new_gate.md to read a quick explanation of the main steps necessary.
+
+## Citation
+
+If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+
+```
+@misc{qoqo2025,
+      title={qoqo - toolkit to represent quantum circuits},
+      author={HQS Quantum Simulations GmbH},
+      year={2025},
+      url={https://github.com/HQSquantumsimulations/qoqo},
+}
+```

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ bit_registers, float_registers, complex_registers = backend.run_circuit(circuit)
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).
 
-## Contributing
+## Contribution
 
-We welcome contributions to the project. If you want to contribute code, please have a look at CONTRIBUTE.md for our code contribution guidelines.
+We welcome contributions to the project. If you want to contribute code, please have a look at [CONTRIBUTE.md](https://github.com/HQSquantumsimulations/qoqo/blob/main/CONTRIBUTE.md) for our code contribution guidelines.
 
-In order to facilitate the contribution of the addition of a new gate, please also have a look at add_new_gate.md to read a quick explanation of the main steps necessary.
+In order to facilitate the contribution of the addition of a new gate, please also have a look at [add_new_gate.md](https://github.com/HQSquantumsimulations/qoqo/blob/main/add_new_gate.md) to read a quick explanation of the main steps necessary.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of [reduplication](https://en.wikipedia.org/wiki/Reduplication). 
 
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
 
 What qoqo is:
 
@@ -47,11 +47,11 @@ On Linux, macOS and Windows on x86 precompiled packages can be found on PyPi and
 pip install qoqo
 ```
 
-If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain as described [here](./qoqo/README_qoqo.md).
+If no pre-built python wheel is available for your architecture, you can install qoqo from the source distribution using a rust toolchain as described [here](./qoqo/README_qoqo.md).
 
 ## Create your first circuit in qoqo
 
-The following code snippet can be used to create your first circuit in qoqo. For an expanded collection of **examples** please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). 
+The following code snippet can be used to create your first circuit in qoqo. For an expanded collection of **examples** please see the jupyter notebooks in the [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples) repository.
 
 ```python
 from qoqo import Circuit
@@ -97,7 +97,7 @@ In order to facilitate the contribution of the addition of a new gate, please al
 
 ## Citation
 
-If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+If you use **qoqo**, please cite it by including the URL of this github repository, or using the provided BibTeX entry:
 
 ```
 @misc{qoqo2021,

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ In order to facilitate the contribution of the addition of a new gate, please al
 If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
 
 ```
-@misc{qoqo2025,
+@misc{qoqo2021,
       title={qoqo - toolkit to represent quantum circuits},
       author={HQS Quantum Simulations GmbH},
-      year={2025},
+      year={2021},
       url={https://github.com/HQSquantumsimulations/qoqo},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@
 [![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/qoqo)
 ![Crates.io](https://img.shields.io/crates/l/qoqo)
 
-**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of reduplication. 
+**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of [reduplication](https://en.wikipedia.org/wiki/Reduplication). 
 
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
-
-<img src="./documentation/src/images/Introduction_Graphics.png" alt="qoqo" width="70%">
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
 
 What qoqo is:
 
@@ -22,6 +20,10 @@ What qoqo is:
 * A way to serialize quantum circuits and measurement information.
 * A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_qiskit](https://github.com/HQSquantumsimulations/qoqo-qiskit), [qoqo_for_braket](https://github.com/HQSquantumsimulations/qoqo-for-braket), [qoqo_iqm](https://github.com/HQSquantumsimulations/qoqo_iqm)).
 
+
+<img src="./documentation/src/images/Introduction_Graphics.png" alt="qoqo" width="70%">
+
+
 What qoqo is **not**:
 
 * A decomposer translating circuits to a specific set of gates
@@ -29,6 +31,7 @@ What qoqo is **not**:
 * A collection of quantum algorithms
 
 If you are looking for a comprehensive package that integrates all these features, we invite you to explore our [HQStage](https://cloud.quantumsimulations.de/) software.
+
 
 This repository contains two components:
 
@@ -44,19 +47,7 @@ On Linux, macOS and Windows on x86 precompiled packages can be found on PyPi and
 pip install qoqo
 ```
 
-### Installing from source (optional)
-
-If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain (for example available via rustup) and maturin (also available via pip). After installing the rust toolchain and maturing run the same pip install command as above. In some cases on macOS it can be necessary to provide specific linker arguments as shown below:
-
-```shell
-# can be necessary on mscOS
-RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" pip install qoqo
-```
-
-```shell
-RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -m qoqo/Cargo.toml  --release
-pip install target/wheels/$NAME_OF_WHEEL
-```
+If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain as described [here](./qoqo/README_qoqo.md).
 
 ## Create your first circuit in qoqo
 

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -1,5 +1,3 @@
-<img src="qoqo_Logo_vertical_color.png" alt="qoqo logo" width="300" />
-
 # qoqo
 
 [![Documentation Status](https://img.shields.io/badge/docs-read-blue)](https://hqsquantumsimulations.github.io/qoqo/)
@@ -19,10 +17,6 @@ What qoqo is:
 * A thin runtime to run quantum measurements.
 * A way to serialize quantum circuits and measurement information.
 * A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_qiskit](https://github.com/HQSquantumsimulations/qoqo-qiskit), [qoqo_for_braket](https://github.com/HQSquantumsimulations/qoqo-for-braket), [qoqo_iqm](https://github.com/HQSquantumsimulations/qoqo_iqm)).
-
-
-<img src="../documentation/src/images/Introduction_Graphics.png" alt="qoqo" width="70%">
-
 
 What qoqo is **not**:
 

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -99,3 +99,22 @@ bit_registers, float_registers, complex_registers = backend.run_circuit(circuit)
 ## Support
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).
+
+## Contribution
+
+We welcome contributions to the project. If you want to contribute code, please have a look at [CONTRIBUTE.md](https://github.com/HQSquantumsimulations/qoqo/blob/main/CONTRIBUTE.md) for our code contribution guidelines.
+
+In order to facilitate the contribution of the addition of a new gate, please also have a look at [add_new_gate.md](https://github.com/HQSquantumsimulations/qoqo/blob/main/add_new_gate.md) to read a quick explanation of the main steps necessary.
+
+## Citation
+
+If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+
+```
+@misc{qoqo2021,
+      title={qoqo - toolkit to represent quantum circuits},
+      author={HQS Quantum Simulations GmbH},
+      year={2021},
+      url={https://github.com/HQSquantumsimulations/qoqo},
+}
+```

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -1,32 +1,64 @@
 # qoqo
 
-Quantum Operation Quantum Operation  
-Yes we use [reduplication](https://en.wikipedia.org/wiki/Reduplication)
-
-qoqo/roqoqo is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de).
-
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
-
-What roqoqo/qoqo is:
-
-* A toolkit to represent quantum programs including circuits and measurement information
-* A thin runtime to run quantum measurements
-* A way to serialize quantum circuits and measurement information
-* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_mock](https://github.com/HQSquantumsimulations/qoqo_mock), [qoqo_qasm](https://github.com/HQSquantumsimulations/qoqo_qasm))
-
-What roqoqo/qoqo is **not**:
-
-* A decomposer translating circuits to a specific set of gates
-* A quantum circuit optimizer
-* A collection of quantum algorithms
-
-
 [![Documentation Status](https://img.shields.io/badge/docs-read-blue)](https://hqsquantumsimulations.github.io/qoqo/)
 [![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo/actions)
 [![PyPI](https://img.shields.io/pypi/v/qoqo)](https://pypi.org/project/qoqo/)
 [![PyPI - Format](https://img.shields.io/pypi/format/qoqo)](https://pypi.org/project/qoqo/)
 [![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/qoqo)
 ![Crates.io](https://img.shields.io/crates/l/qoqo)
+
+**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of reduplication. 
+
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
+
+What qoqo is:
+
+* A toolkit to represent quantum programs including circuits and measurement information
+* A thin runtime to run quantum measurements
+* A way to serialize quantum circuits and measurement information
+* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_mock](https://github.com/HQSquantumsimulations/qoqo_mock), [qoqo_qasm](https://github.com/HQSquantumsimulations/qoqo_qasm))
+
+What qoqo is **not**:
+
+* A decomposer translating circuits to a specific set of gates
+* A quantum circuit optimizer
+* A collection of quantum algorithms
+
+
+## Installation
+
+On Linux, macOS and Windows on x86 precompiled packages can be found on PyPi and installed via
+
+```shell
+pip install qoqo
+```
+
+### Installing from source (optional)
+
+If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain (for example available via rustup) and maturin (also available via pip). After installing the rust toolchain and maturing run the same pip install command as above. In some cases on macOS it can be necessary to provide specific linker arguments as shown below:
+
+```shell
+# can be necessary on mscOS
+RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" pip install qoqo
+```
+
+```shell
+RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -m qoqo/Cargo.toml  --release
+pip install target/wheels/$NAME_OF_WHEEL
+```
+
+### Using in a rust project
+
+When using qoqo in a rust project providing a python interface add
+
+```TOML
+qoqo = {version="1.0.0", default-features=false}
+```
+
+to the `[dependencies]` section of the project Cargo.toml.
+
+
+## Features
 
 qoqo provides the Python interface to the underlying roqoqo library, including:
 
@@ -38,28 +70,3 @@ qoqo provides the Python interface to the underlying roqoqo library, including:
 * Readout based on classical registers
 * Measurement classes for evaluating observable measurements based on raw readout date returned by quantum computer backends
 * Serialization to json and deserialization from json for circuits and measurement information. Serialization support can easily be expanded to other targets with the help of the serde crate.
-
-This project is partly supported by [PlanQK](https://planqk.de).
-
-### Installation
-
-On Linux, macOS and Windows on x86 precompiled packages can be found on PyPi and installed via
-
-```shell
-pip install qoqo
-```
-
-If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain (for example available via rustup) and maturin (also available via pip). After installing the rust toolchain and maturing run the same pip install command as above. In some cases on macOS it can be necessary to provide specific linker arguments as shown below:
-
-```shell
-# can be necessary on macOS
-pip install qoqo
-```
-
-When using qoqo in a rust project providing a python interface add
-
-```TOML
-qoqo = {version="1.0.0", default-features=false}
-```
-
-to the `[dependencies]` section of the project Cargo.toml.

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -1,28 +1,36 @@
+<img src="qoqo_Logo_vertical_color.png" alt="qoqo logo" width="300" />
+
 # qoqo
 
 [![Documentation Status](https://img.shields.io/badge/docs-read-blue)](https://hqsquantumsimulations.github.io/qoqo/)
-[![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo/actions)
+![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/actions/workflows/hqs-ci-test-rust-pyo3.yml/badge.svg)
 [![PyPI](https://img.shields.io/pypi/v/qoqo)](https://pypi.org/project/qoqo/)
 [![PyPI - Format](https://img.shields.io/pypi/format/qoqo)](https://pypi.org/project/qoqo/)
 [![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/qoqo)
 ![Crates.io](https://img.shields.io/crates/l/qoqo)
 
-**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). 
+**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of [reduplication](https://en.wikipedia.org/wiki/Reduplication). 
 
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
 
 What qoqo is:
 
-* A toolkit to represent quantum programs including circuits and measurement information
-* A thin runtime to run quantum measurements
-* A way to serialize quantum circuits and measurement information
-* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_mock](https://github.com/HQSquantumsimulations/qoqo_mock), [qoqo_qasm](https://github.com/HQSquantumsimulations/qoqo_qasm))
+* A toolkit to represent quantum programs including circuits and measurement information.
+* A thin runtime to run quantum measurements.
+* A way to serialize quantum circuits and measurement information.
+* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_qiskit](https://github.com/HQSquantumsimulations/qoqo-qiskit), [qoqo_for_braket](https://github.com/HQSquantumsimulations/qoqo-for-braket), [qoqo_iqm](https://github.com/HQSquantumsimulations/qoqo_iqm)).
+
+
+<img src="../documentation/src/images/Introduction_Graphics.png" alt="qoqo" width="70%">
+
 
 What qoqo is **not**:
 
 * A decomposer translating circuits to a specific set of gates
 * A quantum circuit optimizer
 * A collection of quantum algorithms
+
+If you are looking for a comprehensive package that integrates all these features, we invite you to explore our [HQStage](https://cloud.quantumsimulations.de/) software.
 
 
 ## Installation
@@ -58,9 +66,32 @@ qoqo = {version="1.0.0", default-features=false}
 to the `[dependencies]` section of the project Cargo.toml.
 
 
+## Create your first circuit in qoqo
+
+The following code snippet can be used to create your first circuit in qoqo. For an expanded collection of **examples** please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). 
+
+```python
+from qoqo import Circuit
+from qoqo import operations as ops
+from qoqo_quest import Backend
+
+circuit = Circuit()
+circuit += ops.DefinitionBit(name="classical_reg", length=2, is_output=True)
+circuit += ops.PauliX(qubit=0)
+circuit += ops.CNOT(0,1)
+circuit += ops.PragmaDamping(qubit=0, gate_time=0.1, rate=0.1)
+circuit += ops.PragmaDamping(qubit=1, gate_time=0.1, rate=0.1)
+circuit += ops.MeasureQubit(qubit=0, readout="classical_reg", readout_index=0)
+circuit += ops.MeasureQubit(qubit=1, readout="classical_reg", readout_index=1)
+circuit += ops.PragmaSetNumberOfMeasurements(number_measurements=1000, readout="classical_reg")
+
+backend = Backend(number_qubits=2)
+bit_registers, float_registers, complex_registers = backend.run_circuit(circuit)
+```
+
 ## Features
 
-qoqo provides the Python interface to the underlying roqoqo library, including:
+**qoqo** provides the following functionalities and features:
 
 * A `Circuit` class to represent quantum circuits
 * A `QuantumProgram` class to represent quantum programs 
@@ -70,3 +101,26 @@ qoqo provides the Python interface to the underlying roqoqo library, including:
 * Readout based on classical registers
 * Measurement classes for evaluating observable measurements based on raw readout date returned by quantum computer backends
 * Serialization to json and deserialization from json for circuits and measurement information. Serialization support can easily be expanded to other targets with the help of the serde crate.
+
+## Support
+
+This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).
+
+## Contributing
+
+We welcome contributions to the project. If you want to contribute code, please have a look at CONTRIBUTE.md for our code contribution guidelines.
+
+In order to facilitate the contribution of the addition of a new gate, please also have a look at add_new_gate.md to read a quick explanation of the main steps necessary.
+
+## Citation
+
+If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+
+```
+@misc{qoqo2021,
+      title={qoqo - toolkit to represent quantum circuits},
+      author={HQS Quantum Simulations GmbH},
+      year={2021},
+      url={https://github.com/HQSquantumsimulations/qoqo},
+}
+```

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -96,6 +96,8 @@ bit_registers, float_registers, complex_registers = backend.run_circuit(circuit)
 * Measurement classes for evaluating observable measurements based on raw readout date returned by quantum computer backends
 * Serialization to json and deserialization from json for circuits and measurement information. Serialization support can easily be expanded to other targets with the help of the serde crate.
 
+Please refer to the [API documentation](https://hqsquantumsimulations.github.io/qoqo/python_api_docs/index.html) for technical details on qoqo functions.
+
 ## Support
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -99,22 +99,3 @@ bit_registers, float_registers, complex_registers = backend.run_circuit(circuit)
 ## Support
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).
-
-## Contributing
-
-We welcome contributions to the project. If you want to contribute code, please have a look at CONTRIBUTE.md for our code contribution guidelines.
-
-In order to facilitate the contribution of the addition of a new gate, please also have a look at add_new_gate.md to read a quick explanation of the main steps necessary.
-
-## Citation
-
-If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
-
-```
-@misc{qoqo2021,
-      title={qoqo - toolkit to represent quantum circuits},
-      author={HQS Quantum Simulations GmbH},
-      year={2021},
-      url={https://github.com/HQSquantumsimulations/qoqo},
-}
-```

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -9,7 +9,7 @@
 
 **qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of [reduplication](https://en.wikipedia.org/wiki/Reduplication). 
 
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
 
 What qoqo is:
 
@@ -37,7 +37,7 @@ pip install qoqo
 
 ### Installing from source (optional)
 
-If no pre-built python wheel is available for your architecture you can install qoqo from the source distribution using a rust toolchain (for example available via rustup) and maturin (also available via pip). After installing the rust toolchain and maturing run the same pip install command as above. In some cases on macOS it can be necessary to provide specific linker arguments as shown below:
+If no pre-built python wheel is available for your architecture, you can install qoqo from the source distribution using a rust toolchain (for example available via rustup) and maturin (also available via pip). After installing the rust toolchain and maturing run the same pip install command as above. In some cases on macOS it can be necessary to provide specific linker arguments as shown below:
 
 ```shell
 # can be necessary on mscOS
@@ -62,7 +62,7 @@ to the `[dependencies]` section of the project Cargo.toml.
 
 ## Create your first circuit in qoqo
 
-The following code snippet can be used to create your first circuit in qoqo. For an expanded collection of **examples** please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). 
+The following code snippet can be used to create your first circuit in qoqo. For an expanded collection of **examples** please see the jupyter notebooks in the [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples) repository.
 
 ```python
 from qoqo import Circuit
@@ -110,7 +110,7 @@ In order to facilitate the contribution of the addition of a new gate, please al
 
 ## Citation
 
-If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+If you use **qoqo**, please cite it by including the URL of this github repository, or using the provided BibTeX entry:
 
 ```
 @misc{qoqo2021,

--- a/qoqo/README_qoqo.md
+++ b/qoqo/README_qoqo.md
@@ -7,7 +7,7 @@
 [![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/qoqo)
 ![Crates.io](https://img.shields.io/crates/l/qoqo)
 
-**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). The name “qoqo” stands for “Quantum Operation Quantum Operation,” making use of reduplication. 
+**qoqo** is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). 
 
 For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
 

--- a/roqoqo/README_roqoqo.md
+++ b/roqoqo/README_roqoqo.md
@@ -1,6 +1,12 @@
 # roqoqo
 
-roqoqo is a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de).
+[![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/roqoqo)
+[![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo/actions)
+[![docs.rs](https://img.shields.io/docsrs/roqoqo)](https://docs.rs/roqoqo/)
+![Crates.io](https://img.shields.io/crates/l/roqoqo)
+[![codecov](https://codecov.io/gh/HQSquantumsimulations/qoqo/branch/main/graph/badge.svg?token=S1IN066V2W)](https://codecov.io/gh/HQSquantumsimulations/qoqo)
+
+roqoqo is the core rust library for **qoqo** - a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). 
 
 For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
 
@@ -9,7 +15,7 @@ What roqoqo is:
 * A toolkit to represent quantum programs including circuits and measurement information
 * A thin runtime to run quantum measurements
 * A way to serialize quantum circuits and measurement information
-* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_mock](https://github.com/HQSquantumsimulations/qoqo_mock), [qoqo_qasm](https://github.com/HQSquantumsimulations/qoqo_qasm))
+* A set of optional interfaces to devices, simulators and toolkits (e.g. [qoqo_quest](https://github.com/HQSquantumsimulations/qoqo-quest), [qoqo_qiskit](https://github.com/HQSquantumsimulations/qoqo-qiskit), [qoqo_for_braket](https://github.com/HQSquantumsimulations/qoqo-for-braket), [qoqo_iqm](https://github.com/HQSquantumsimulations/qoqo_iqm))
 
 What roqoqo is **not**:
 
@@ -17,13 +23,34 @@ What roqoqo is **not**:
 * A quantum circuit optimizer
 * A collection of quantum algorithms
 
-## roqoqo
+## Installation
 
-[![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/roqoqo)
-[![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo/actions)
-[![docs.rs](https://img.shields.io/docsrs/roqoqo)](https://docs.rs/roqoqo/)
-![Crates.io](https://img.shields.io/crates/l/roqoqo)
-[![codecov](https://codecov.io/gh/HQSquantumsimulations/qoqo/branch/main/graph/badge.svg?token=S1IN066V2W)](https://codecov.io/gh/HQSquantumsimulations/qoqo)
+To use roqoqo in a Rust project simply add
+
+```TOML
+roqoqo = {version="1.0"}
+```
+
+to the `[dependencies]` section of the project Cargo.toml.
+
+
+When using qoqo in a rust project providing a python interface add
+
+```TOML
+qoqo = {version="1.0", default-features=false}
+```
+
+to the `[dependencies]` section of the project Cargo.toml.
+
+A source distribution now exists but requires a Rust install with a rust version > 1.47 and a maturin version { >= 0.12, <0.13 } in order to be built.
+
+## Examples
+
+For an expanded collection of examples please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). The qoqo examples require the qoqo_quest and qoqo_mock interfaces.
+
+The jupyter notebooks in **Rust** can be found in [qoqo_examples/roqoqo/notebooks/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/roqoqo/notebooks). Alternatively, you can also find pure **Rust** versions of the examples in [qoqo_examples/roqoqo/standalone/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/roqoqo/standalone)
+
+## Features
 
 roqoqo provides:
 
@@ -38,17 +65,3 @@ roqoqo provides:
 * An `EvaluatingBackend` trait defining a standard for interfacing from qoqo to hardware and simulators that can return measured values
 * A `Device` trait defining a standard to obtain connectivity information and a noise model for quantum computing devices
 * Serialize and deserialize support for `Circuit` and `QuantumProgram` via the serde crate.
-
-This software is still in the beta stage. Functions and documentation are not yet complete and breaking changes can occur.
-
-This project is partly supported by [PlanQK](https://planqk.de).
-
-### Installation
-
-To use roqoqo in a Rust project simply add
-
-```TOML
-roqoqo = {version="1.0"}
-```
-
-to the `[dependencies]` section of the project Cargo.toml.

--- a/roqoqo/README_roqoqo.md
+++ b/roqoqo/README_roqoqo.md
@@ -1,7 +1,7 @@
 # roqoqo
 
 [![Crates.io](https://img.shields.io/crates/v/roqoqo)](https://crates.io/crates/roqoqo)
-[![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo/actions)
+![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo/actions/workflows/hqs-ci-test-rust-pyo3.yml/badge.svg)
 [![docs.rs](https://img.shields.io/docsrs/roqoqo)](https://docs.rs/roqoqo/)
 ![Crates.io](https://img.shields.io/crates/l/roqoqo)
 [![codecov](https://codecov.io/gh/HQSquantumsimulations/qoqo/branch/main/graph/badge.svg?token=S1IN066V2W)](https://codecov.io/gh/HQSquantumsimulations/qoqo)
@@ -22,6 +22,10 @@ What roqoqo is **not**:
 * A decomposer translating circuits to a specific set of gates
 * A quantum circuit optimizer
 * A collection of quantum algorithms
+
+
+If you are looking for a comprehensive package that integrates all these features, we invite you to explore our [HQStage](https://cloud.quantumsimulations.de/) software.
+
 
 ## Installation
 
@@ -65,3 +69,7 @@ roqoqo provides:
 * An `EvaluatingBackend` trait defining a standard for interfacing from qoqo to hardware and simulators that can return measured values
 * A `Device` trait defining a standard to obtain connectivity information and a noise model for quantum computing devices
 * Serialize and deserialize support for `Circuit` and `QuantumProgram` via the serde crate.
+
+## Support
+
+This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).

--- a/roqoqo/README_roqoqo.md
+++ b/roqoqo/README_roqoqo.md
@@ -73,3 +73,22 @@ roqoqo provides:
 ## Support
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).
+
+## Contribution
+
+We welcome contributions to the project. If you want to contribute code, please have a look at [CONTRIBUTE.md](https://github.com/HQSquantumsimulations/qoqo/blob/main/CONTRIBUTE.md) for our code contribution guidelines.
+
+In order to facilitate the contribution of the addition of a new gate, please also have a look at [add_new_gate.md](https://github.com/HQSquantumsimulations/qoqo/blob/main/add_new_gate.md) to read a quick explanation of the main steps necessary.
+
+## Citation
+
+If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+
+```
+@misc{qoqo2021,
+      title={qoqo - toolkit to represent quantum circuits},
+      author={HQS Quantum Simulations GmbH},
+      year={2021},
+      url={https://github.com/HQSquantumsimulations/qoqo},
+}
+```

--- a/roqoqo/README_roqoqo.md
+++ b/roqoqo/README_roqoqo.md
@@ -70,6 +70,8 @@ roqoqo provides:
 * A `Device` trait defining a standard to obtain connectivity information and a noise model for quantum computing devices
 * Serialize and deserialize support for `Circuit` and `QuantumProgram` via the serde crate.
 
+Please refer to the [API documentation](https://docs.rs/roqoqo/latest/roqoqo/) for technical details on roqoqo functionalities.
+
 ## Support
 
 This project has been partly supported by [PlanQK](https://planqk.de) and is partially supported by [QSolid](https://www.q-solid.de/) and [PhoQuant](https://www.quantentechnologien.de/forschung/foerderung/quantencomputer-demonstrationsaufbauten/phoquant.html).

--- a/roqoqo/README_roqoqo.md
+++ b/roqoqo/README_roqoqo.md
@@ -8,7 +8,7 @@
 
 roqoqo is the core rust library for **qoqo** - a toolkit to represent quantum circuits by [HQS Quantum Simulations](https://quantumsimulations.de). 
 
-For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo_examples/) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples)
+For a detailed introduction see the [user documentation](https://hqsquantumsimulations.github.io/qoqo) and the [qoqo examples repository](https://github.com/HQSquantumsimulations/qoqo_examples).
 
 What roqoqo is:
 
@@ -46,11 +46,11 @@ qoqo = {version="1.0", default-features=false}
 
 to the `[dependencies]` section of the project Cargo.toml.
 
-A source distribution now exists but requires a Rust install with a rust version > 1.47 and a maturin version { >= 0.12, <0.13 } in order to be built.
+A source distribution now exists but requires a Rust install with a rust version > 1.76 and a maturin version { >=1.0 } in order to be built.
 
 ## Examples
 
-For an expanded collection of examples please see the jupyter notebooks in the extra repository [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples). The qoqo examples require the qoqo_quest and qoqo_mock interfaces.
+For an expanded collection of examples please see the jupyter notebooks in the [qoqo_examples](https://github.com/HQSquantumsimulations/qoqo_examples) repository. The qoqo examples require the qoqo_quest and qoqo_mock interfaces.
 
 The jupyter notebooks in **Rust** can be found in [qoqo_examples/roqoqo/notebooks/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/roqoqo/notebooks). Alternatively, you can also find pure **Rust** versions of the examples in [qoqo_examples/roqoqo/standalone/](https://github.com/HQSquantumsimulations/qoqo_examples/tree/main/roqoqo/standalone)
 
@@ -84,7 +84,7 @@ In order to facilitate the contribution of the addition of a new gate, please al
 
 ## Citation
 
-If you use **qoqo**, please cite by including the URL of this github repository or as per the provided BibTeX entry:
+If you use **qoqo**, please cite it by including the URL of this github repository, or using the provided BibTeX entry:
 
 ```
 @misc{qoqo2021,


### PR DESCRIPTION
* roqoqo removed from the main readme and move to the individual roqoqo readme
* citation info added
* simple example added
* installation information simplified and splitted across individual qoqo/roqoqo readmes
* linked backends updated (braket and iqm added)
* file structure streamlined